### PR TITLE
Add Kramer blog post and modernize about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,7 +8,7 @@ navbar: true
 
 <img src="/img/profile.jpg" alt="Itamar Weiss" style="width:194px">
 
-I help companies turn AI and data from "interesting experiment" into something the business actually relies on. Most teams can build an impressive demo in a week. The hard part is everything after that - making the system trustworthy, governed, and useful enough that people change how they work because of it. That's where I come in.
+I help companies turn AI and data from "interesting experiment" into something the business actually relies on. Most teams can build an impressive demo in a week. The hard part is everything after that - making the system trustworthy, governed, and useful enough that people change how they work because of it. That's where I come in - usually with my hands on the keyboard, writing the code alongside your team.
 
 ## What I help with
 
@@ -20,7 +20,7 @@ I help companies turn AI and data from "interesting experiment" into something t
 
 ## How I work
 
-I work with founders, CTOs, and engineering leaders - sometimes hands-on building, sometimes as an advisor helping the team make the right architectural calls. Engagements range from a focused one-off ("help us decide between these three approaches and de-risk the first 4 weeks") to longer partnerships where I'm embedded with a team. I try to push back when I think a project is over-scoped, and I'd rather tell you the boring answer than sell you a flashy one.
+Most of my work is hands-on building. I embed with a team, write production code, set up the pipelines, wire up the evals, ship the feature - and along the way, help with the architectural calls that shape what gets built. Sometimes engagements are purely advisory ("help us decide between these three approaches"), but more often they're a mix: build the first version, prove it works, and hand off something the team can own and extend. I try to push back when I think a project is over-scoped, and I'd rather tell you the boring answer than sell you a flashy one.
 
 ## The stack I tend to reach for
 
@@ -28,4 +28,4 @@ Python, TypeScript, React, Node.js for the application layer. Postgres, Snowflak
 
 ## Get in touch
 
-If you're trying to ship something in this space and want a second opinion or a partner for the build, I'd be happy to talk. The fastest way to reach me is by [email](mailto:me@itamarweiss.com).
+If you're trying to ship something in this space and want a builder on your team - or a partner to bounce architecture off - I'd be happy to talk. The fastest way to reach me is by [email](mailto:me@itamarweiss.com).

--- a/about.md
+++ b/about.md
@@ -2,16 +2,30 @@
 layout: page
 title: About
 permalink: /about/
-excerpt: "Expert consulting in AI, machine learning, big data, data science, high-scale distributed systems, cloud architecture, security, blockchain, and decentralized technologies."
+excerpt: "Consulting on data platforms, AI agents, and shipping AI features to production. Helping teams turn AI experiments into reliable, governed systems people actually use."
 navbar: true
 ---
 
 <img src="/img/profile.jpg" alt="Itamar Weiss" style="width:194px">
 
-I offer expert consulting in AI and machine learning, specializing in advanced techniques such as PyTorch, convolutional neural networks (ConvNets), large language models (LLMs), retrieval-augmented generation (RAG), fine-tuning, diffusion networks, and autoencoders. My work focuses on developing and deploying intelligent systems that provide measurable business impact, using cutting-edge methodologies to solve complex problems.
+I help companies turn AI and data from "interesting experiment" into something the business actually relies on. Most teams can build an impressive demo in a week. The hard part is everything after that - making the system trustworthy, governed, and useful enough that people change how they work because of it. That's where I come in.
 
-I have extensive experience in building and optimizing high-scale distributed systems using technologies like Apache Kafka, Apache Spark, PySpark, Databricks, Snowflake, AWS Redshift, and Google Cloud Platform (GCP). I am proficient in designing cloud-native architectures and scalable data pipelines on platforms such as AWS (including EMR), GCP, and Azure, ensuring high performance, reliability, and security for data-intensive applications.
+## What I help with
 
-Additionally, I specialize in modern application development frameworks such as Node.js and Angular, and I have a deep understanding of blockchain technologies and virtual currencies. My expertise includes creating secure messaging systems, decentralized applications, and other innovative solutions in the space of cybersecurity and distributed ledger technologies.
+**Data platforms & analytics that anyone in the company can use.** Semantic layers, warehouses, pipelines, and the analytics tooling that sits on top. The goal is usually the same: democratize data so a sales rep, a PM, or an exec can answer their own questions without waiting for an analyst. That includes building internal data agents (like the ones I [write about on my blog](/ai/code/2026/05/13/ai-for-data-questions-blueprint.html)) - the kind that combine a semantic layer, governed access, and domain skills into something employees actually trust.
 
-I partner with organizations to leverage the power of AI, machine learning, and distributed systems to drive innovation, optimize operations, and scale effectively in today's fast-paced digital landscape.
+**AI agents and assistants that do real work.** Custom agents and copilots, MCP-based capabilities, RAG systems over your internal knowledge, and the evaluation harnesses that keep them honest. I focus on the parts most teams underinvest in: scoping the agent to one job it can actually do well, building benchmarks before features, and designing for governance from day one.
+
+**Getting AI features to production.** A lot of AI work stalls between a working prototype and something a customer touches. I help close that gap - turning a notebook or a Cursor session into a system with latency budgets, eval suites, cost controls, observability, and a sensible fallback when the model gets it wrong.
+
+## How I work
+
+I work with founders, CTOs, and engineering leaders - sometimes hands-on building, sometimes as an advisor helping the team make the right architectural calls. Engagements range from a focused one-off ("help us decide between these three approaches and de-risk the first 4 weeks") to longer partnerships where I'm embedded with a team. I try to push back when I think a project is over-scoped, and I'd rather tell you the boring answer than sell you a flashy one.
+
+## The stack I tend to reach for
+
+Python, TypeScript, React, Node.js for the application layer. Postgres, Snowflake, BigQuery, dbt for data. Kafka and Spark when scale calls for it. For AI: the Anthropic and OpenAI APIs, MCP, vector stores, LangGraph / Claude Agent SDK, and a healthy obsession with evals. Cloud-wise, mostly AWS and GCP. The specific tools matter less than picking the right ones for the constraints you're under - and being willing to swap them out when something better shows up.
+
+## Get in touch
+
+If you're trying to ship something in this space and want a second opinion or a partner for the build, I'd be happy to talk. The fastest way to reach me is by [email](mailto:me@itamarweiss.com).


### PR DESCRIPTION
## Summary

- **New blog post** (`_posts/2026-05-13-ai-for-data-questions-blueprint.md`) summarizing monday.com's *Startup for Startup* episode 348 about Kramer — their internal AI agent for democratizing data. Covers the six building blocks (semantic layer, skills, benchmarks, governance, MCP, customization), the public-company governance angle, internal hackathons for sourcing skills, and the agent's viral adoption inside monday.com.
- **Modernized about page** with three goal-oriented offerings (data platforms & analytics, AI agents & assistants, shipping AI to production) instead of a tech buzzword list. Refreshed the stack section (React in, Angular out; added MCP, Claude Agent SDK, dbt, vector stores; dropped dated blockchain/crypto framing). Reframed engagements as primarily hands-on building.

## Test plan

- [ ] Confirm the blog post renders correctly on the published site (Hebrew URL in the Startup for Startup link decodes cleanly).
- [ ] Verify the cross-link from `about.md` to the new blog post resolves (`/ai/code/2026/05/13/ai-for-data-questions-blueprint.html`).
- [ ] Sanity-check the new about page reads well on mobile.
- [ ] Consider whether the portfolio page should be trimmed of dated blockchain/crypto projects to match the new about positioning (separate PR).

https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA)_