### PR TITLE
Fix dead cross-link on about page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# itamarwe.github.io
+
+Jekyll site published via GitHub Pages.
+
+## Always verify links before adding them
+
+This is a static site, so a typo in an internal link is a dead link in production. Before adding any link in a markdown file:
+
+- **External links**: confirm the URL resolves (WebFetch or WebSearch).
+- **Internal links**: confirm the target file exists and the URL matches Jekyll's actual generated path. The default permalink is `/:categories/:year/:month/:day/:title.html`, so the URL depends on the post's `categories:` frontmatter. Cross-check against an existing post's link to confirm the path format.
+- **Watch the `categories:` field**: writing `categories: ai, code` as a comma-separated string does **not** produce `/ai/code/...` — Jekyll needs a YAML list (`categories: [ai, code]` or block style) or space-separated values.

--- a/about.md
+++ b/about.md
@@ -12,7 +12,7 @@ I help companies turn AI and data from "interesting experiment" into something t
 
 ## What I help with
 
-**Data platforms & analytics that anyone in the company can use.** Semantic layers, warehouses, pipelines, and the analytics tooling that sits on top. The goal is usually the same: democratize data so a sales rep, a PM, or an exec can answer their own questions without waiting for an analyst. That includes building internal data agents (like the ones I [write about on my blog](/ai/code/2026/05/13/ai-for-data-questions-blueprint.html)) - the kind that combine a semantic layer, governed access, and domain skills into something employees actually trust.
+**Data platforms & analytics that anyone in the company can use.** Semantic layers, warehouses, pipelines, and the analytics tooling that sits on top. The goal is usually the same: democratize data so a sales rep, a PM, or an exec can answer their own questions without waiting for an analyst. That includes building internal data agents - the kind that combine a semantic layer, governed access, and domain skills into something employees actually trust.
 
 **AI agents and assistants that do real work.** Custom agents and copilots, MCP-based capabilities, RAG systems over your internal knowledge, and the evaluation harnesses that keep them honest. I focus on the parts most teams underinvest in: scoping the agent to one job it can actually do well, building benchmarks before features, and designing for governance from day one.
 


### PR DESCRIPTION
## Summary

- Removes the dead `/ai/code/2026/05/13/...` cross-link from the about page. It pointed at a permalink Jekyll never generated because the post's `categories:` frontmatter is a comma-separated string rather than a YAML list.
- Adds project-level `CLAUDE.md` with a note to verify links before adding them, including the specific Jekyll permalink/categories gotcha that caused this regression.

## Test plan

- [ ] Confirm the about page renders without the dead link.
- [ ] Spot-check remaining links on the about page (`mailto:` and any others) still resolve.

https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA)_