### PR TITLE
Modernize blog look and feel

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -23,6 +23,8 @@ body {
     -o-font-feature-settings: "kern" 1;
     font-feature-settings: "kern" 1;
     font-kerning: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 
@@ -82,7 +84,7 @@ li {
  * Headings
  */
 h1, h2, h3, h4, h5, h6 {
-    font-weight: $base-font-weight;
+    font-weight: 600;
 }
 
 
@@ -92,15 +94,16 @@ h1, h2, h3, h4, h5, h6 {
  */
 a {
     color: $brand-color;
-    text-decoration: none;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.15em;
 
     &:visited {
-        color: darken($brand-color, 15%);
+        color: darken($brand-color, 8%);
     }
 
     &:hover {
-        color: $text-color;
-        text-decoration: underline;
+        text-decoration-thickness: 2px;
     }
 }
 
@@ -114,7 +117,6 @@ blockquote {
     border-left: 4px solid $grey-color-light;
     padding-left: $spacing-unit / 2;
     font-size: 18px;
-    letter-spacing: -1px;
     font-style: italic;
 
     > :last-child {
@@ -129,10 +131,11 @@ blockquote {
  */
 pre,
 code {
-    font-size: 15px;
+    font-family: $mono-font-family;
+    font-size: 0.9em;
     border: 1px solid $grey-color-light;
-    border-radius: 3px;
-    background-color: #eef;
+    border-radius: 4px;
+    background-color: $code-bg-color;
 }
 
 code {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,7 +2,6 @@
  * Site header
  */
 .site-header {
-    border-top: 5px solid $grey-color-dark;
     border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
 
@@ -12,11 +11,11 @@
 
 .site-title {
     font-size: 26px;
-    font-weight: 300;
+    font-weight: 500;
     line-height: 56px;
-    letter-spacing: -1px;
     margin-bottom: 0;
     float: left;
+    text-decoration: none;
 
     &,
     &:visited {
@@ -35,6 +34,7 @@
     .page-link {
         color: $text-color;
         line-height: $base-line-height;
+        text-decoration: none;
 
         // Gaps between nav items, but not on the last one
         &:not(:last-child) {
@@ -192,6 +192,14 @@
 .post-link {
     display: block;
     font-size: 24px;
+    font-weight: 600;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 0.15em;
+    }
 }
 
 
@@ -205,8 +213,8 @@
 
 .post-title {
     font-size: 42px;
-    letter-spacing: -1px;
-    line-height: 1;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
 
     @include media-query($on-laptop) {
         font-size: 36px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -6,21 +6,25 @@
 
 
 // Our variables
-$base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$base-font-size:   16px;
+$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", "Inter", system-ui, Roboto, Helvetica, Arial, sans-serif;
+$mono-font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+$base-font-size:   17px;
 $base-font-weight: 400;
 $small-font-size:  $base-font-size * 0.875;
-$base-line-height: 1.5;
+$base-line-height: 1.65;
 
 $spacing-unit:     30px;
 
-$text-color:       #111;
-$background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
+// Cool neutral (Vercel/Tailwind) palette
+$text-color:       #0f172a;  // slate-900
+$background-color: #ffffff;
+$brand-color:      #2563eb;  // blue-600
 
-$grey-color:       #828282;
-$grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark:  darken($grey-color, 25%);
+$grey-color:       #64748b;  // slate-500
+$grey-color-light: #e2e8f0;  // slate-200
+$grey-color-dark:  #334155;  // slate-700
+
+$code-bg-color:    #f1f5f9;  // slate-100
 
 // Width of the content area
 $content-width:    800px;
@@ -51,3 +55,76 @@ $on-laptop:        800px;
         "layout",
         "syntax-highlighting"
 ;
+
+
+
+// Dark mode — paired with the cool neutral palette
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #0f172a;  // slate-900
+        color: #e2e8f0;             // slate-200
+    }
+
+    a {
+        color: #60a5fa;             // blue-400
+
+        &:visited {
+            color: #93c5fd;         // blue-300
+        }
+
+        &:hover {
+            color: #f1f5f9;         // slate-100
+        }
+    }
+
+    pre,
+    code {
+        background-color: #1e293b;  // slate-800
+        border-color: #334155;      // slate-700
+    }
+
+    blockquote {
+        color: #94a3b8;             // slate-400
+        border-color: #334155;
+    }
+
+    .site-header {
+        border-color: #334155;
+    }
+
+    .site-title,
+    .site-title:visited {
+        color: #e2e8f0;
+    }
+
+    .site-nav .page-link {
+        color: #e2e8f0;
+    }
+
+    .site-nav .menu-icon > svg path {
+        fill: #e2e8f0;
+    }
+
+    .site-footer {
+        border-color: #334155;
+    }
+
+    .footer-col-wrapper {
+        color: #94a3b8;
+    }
+
+    .post-meta {
+        color: #94a3b8;
+    }
+
+    .icon > svg path {
+        fill: #94a3b8;
+    }
+}
+
+@media (prefers-color-scheme: dark) and (max-width: $on-palm) {
+    .site-nav {
+        background-color: #0f172a;
+        border-color: #334155;
+    }
+}


### PR DESCRIPTION
## Summary

Light-touch refresh of the existing Minima-style theme. Same structure, slightly more current visuals. No web fonts, no JS, no new dependencies.

**Typography**
- Modern system font stack (`-apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Inter", ...`)
- Body bumped to 17px / line-height 1.65
- Heading weight 600 (was 400 — headings looked thin)
- Monospace font stack for code

**Color — "cool neutral" palette (Vercel/Tailwind)**
- Text `#0f172a` (slate-900), links `#2563eb` (blue-600)
- Code background `#f1f5f9` (slate-100), replacing the cyan-tinted `#eef`
- Greys realigned to Tailwind slate scale

**Dark mode**
- `prefers-color-scheme: dark` support, no toggle UI or JS
- Background slate-900, text slate-200, links blue-400

**Layout**
- Drop the heavy 5px top border on the site header (kept the subtle bottom border)
- Post titles use relative `letter-spacing: -0.02em` and `line-height: 1.1` (was tight 1.0)
- Links underlined by default with `text-underline-offset` (modern + better accessibility)
- Nav, site title, and post-list links exempt from default underline

## What I deliberately did **not** do

- No web fonts (keeps the site fast and dependency-free)
- No JS, no animations, no dark-mode toggle UI
- No structural HTML/layout changes
- Did not narrow the content width (still 800px — easy follow-up if reading column feels too wide)

## Test plan

- [ ] Verify the GitHub Pages build succeeds (couldn't build locally due to broken bundler in dev env).
- [ ] Visually check the home page, a post page, and the about page in light mode.
- [ ] Toggle OS to dark mode and re-check the same pages.
- [ ] Spot-check mobile / narrow viewport (especially the nav hamburger).

https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV4pN7tdRbgPsjDyvy9PUA)_