### PR TITLE
Improve homepage SEO tags with about-page content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,12 +3,28 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  {% assign page_title = page.title | default: site.title %}
+  {% assign page_description = page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 %}
+  {% assign page_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+
+  <title>{{ page_title | escape }}</title>
+  <meta name="description" content="{{ page_description }}">
+  <meta name="author" content="Itamar Weiss">
   <link rel="shortcut icon" type="image/png" href="/favicon.ico">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ page_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+
+  <meta property="og:title" content="{{ page_title | escape }}">
+  <meta property="og:description" content="{{ page_description }}">
+  <meta property="og:url" content="{{ page_url }}">
+  <meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
+  <meta property="og:image" content="{{ site.url }}/img/profile.jpg">
+  <meta property="og:site_name" content="{{ site.title }}">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@{{ site.twitter_username }}">
+  <meta name="twitter:creator" content="@{{ site.twitter_username }}">
 
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+title: "Itamar Weiss — Hands-on AI & Data Consultant"
+excerpt: "Independent consultant helping teams ship AI agents, data platforms, and production AI features. Hands-on building with Python, TypeScript, and modern AI stacks."
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Itamar Weiss — Hands-on AI & Data Consultant"
-excerpt: "Independent consultant helping teams ship AI agents, data platforms, and production AI features. Hands-on building with Python, TypeScript, and modern AI stacks."
+excerpt: "Helping teams ship AI agents, data platforms, and production AI features. Hands-on building with modern AI and data engineering stacks."
 ---
 
 <div class="home">


### PR DESCRIPTION
Sets a descriptive title and meta description on the homepage so it
reflects the consulting work described on /about/ instead of the generic
'Personal blog by Itamar Weiss' fallback. Adds author, Open Graph, and
Twitter Card tags in the shared head include so the same content
benefits social previews and any non-homepage page.