### PR TITLE
Expand about and portfolio pages with consulting focus and new projects

### DIFF
--- a/about.md
+++ b/about.md
@@ -2,30 +2,16 @@
 layout: page
 title: About
 permalink: /about/
-excerpt: "Consulting on data platforms, AI agents, and shipping AI features to production. Helping teams turn AI experiments into reliable, governed systems people actually use."
+excerpt: "Expert consulting in AI, machine learning, big data, data science, high-scale distributed systems, cloud architecture, security, blockchain, and decentralized technologies."
 navbar: true
 ---
 
 <img src="/img/profile.jpg" alt="Itamar Weiss" style="width:194px">
 
-I help companies turn AI and data from "interesting experiment" into something the business actually relies on. Most teams can build an impressive demo in a week. The hard part is everything after that - making the system trustworthy, governed, and useful enough that people change how they work because of it. That's where I come in - usually with my hands on the keyboard, writing the code alongside your team.
+I offer expert consulting in AI and machine learning, specializing in advanced techniques such as PyTorch, convolutional neural networks (ConvNets), large language models (LLMs), retrieval-augmented generation (RAG), fine-tuning, diffusion networks, and autoencoders. My work focuses on developing and deploying intelligent systems that provide measurable business impact, using cutting-edge methodologies to solve complex problems.
 
-## What I help with
+I have extensive experience in building and optimizing high-scale distributed systems and data engineering platforms using technologies like Apache Kafka, Apache Spark, Apache Flink, Apache Iceberg, PySpark, Java, Databricks, Snowflake, AWS Redshift, and Google Cloud Platform (GCP). I am proficient in designing cloud-native architectures and scalable data pipelines on platforms such as AWS (including EMR), GCP, and Azure, ensuring high performance, reliability, and security for data-intensive applications.
 
-**Data platforms & analytics that anyone in the company can use.** Semantic layers, warehouses, pipelines, and the analytics tooling that sits on top. The goal is usually the same: democratize data so a sales rep, a PM, or an exec can answer their own questions without waiting for an analyst. That includes building internal data agents - the kind that combine a semantic layer, governed access, and domain skills into something employees actually trust.
+Additionally, I specialize in modern application development frameworks such as Node.js and Angular, and I have a deep understanding of blockchain technologies and virtual currencies. My expertise includes creating secure messaging systems, decentralized applications, and other innovative solutions in the space of cybersecurity and distributed ledger technologies.
 
-**AI agents and assistants that do real work.** Custom agents and copilots, MCP-based capabilities, RAG systems over your internal knowledge, and the evaluation harnesses that keep them honest. I focus on the parts most teams underinvest in: scoping the agent to one job it can actually do well, building benchmarks before features, and designing for governance from day one.
-
-**Getting AI features to production.** A lot of AI work stalls between a working prototype and something a customer touches. I help close that gap - turning a notebook or a Cursor session into a system with latency budgets, eval suites, cost controls, observability, and a sensible fallback when the model gets it wrong.
-
-## How I work
-
-Most of my work is hands-on building. I embed with a team, write production code, set up the pipelines, wire up the evals, ship the feature - and along the way, help with the architectural calls that shape what gets built. Sometimes engagements are purely advisory ("help us decide between these three approaches"), but more often they're a mix: build the first version, prove it works, and hand off something the team can own and extend. I try to push back when I think a project is over-scoped, and I'd rather tell you the boring answer than sell you a flashy one.
-
-## The stack I tend to reach for
-
-Python, TypeScript, React, Node.js for the application layer. Postgres, Snowflake, BigQuery, dbt for data. Kafka and Spark when scale calls for it. For AI: the Anthropic and OpenAI APIs, MCP, vector stores, LangGraph / Claude Agent SDK, and a healthy obsession with evals. Cloud-wise, mostly AWS and GCP. The specific tools matter less than picking the right ones for the constraints you're under - and being willing to swap them out when something better shows up.
-
-## Get in touch
-
-If you're trying to ship something in this space and want a builder on your team - or a partner to bounce architecture off - I'd be happy to talk. The fastest way to reach me is by [email](mailto:me@itamarweiss.com).
+I partner with organizations to leverage the power of AI, machine learning, and distributed systems to drive innovation, optimize operations, and scale effectively in today's fast-paced digital landscape.

--- a/portfolio.md
+++ b/portfolio.md
@@ -15,10 +15,40 @@ My career has been driven by a commitment to innovation and excellence, whether 
 
 ## Education:
 
-- B.Sc. in Physics and Mathematics - Hebrew University
+- B.Sc. in Physics and Mathematics - Hebrew University (Dean's List 2002, 2003)
 - M.Sc. in Electrical Engineering - Tel Aviv University
 
 ## Projects:
+
+### Large-Scale Apache Iceberg Deployment
+Deployed and optimized Apache Iceberg at a large-scale defense organization, enabling reliable, high-performance data lake management across petabytes of data. The project involved designing the table format architecture, managing schema evolution, and ensuring seamless integration with existing data infrastructure.
+
+### Scalable Data Pipeline with Apache Flink for a Cybersecurity Startup
+Built a scalable, real-time data pipeline using Apache Flink for a cybersecurity startup. As part of the project, developed an internal framework on top of Flink that allowed teams to define complex, multi-stage streaming pipelines using a single YAML configuration file, dramatically reducing development time and improving pipeline consistency and maintainability.
+
+### Database Lineage Graph Algorithm Optimization
+Upgraded a recursive, graph-based algorithm for computing database column-level lineage. The improved algorithm significantly increased performance and accuracy, enabling the system to handle larger and more complex dependency graphs across enterprise-scale database environments.
+
+### Real-Time Apache Kafka Visualization
+Created a tool to visualize real-time, high-throughput data streams, aggregate statistics, and provide real-time search capabilities, using Node.js, Angular.js, Socket.io, and Apache Kafka.
+
+### Flash-Card Based Spaced Repetition Tool for Memorization
+Developed a user-friendly Facebook app to create and practice flashcards using the [spaced repetition](https://www.supermemo.com/english/ol/sm2.htm) algorithm to optimize learning.
+
+### Angular.js Course
+Designed and instructed a comprehensive one-week Angular.js course, delivered multiple times to developers at [Pictet Private Bank](https://www.group.pictet/) and other front-end developers in Geneva, Switzerland.
+
+### SMS Sending API
+Developed a scalable SMS sending platform with a user-friendly API for a [Kannel](http://www.kannel.org/) server. The platform featured self-service capabilities, allowing users to subscribe, input payment details, and manage SMS campaigns. It also included an admin interface for monitoring system health and activity. Built using Node.js, MongoDB, and Angular.js, the platform supported millions of SMS messages for various marketing campaigns.
+
+### Online Marketplace
+Developed a comprehensive two-sided online marketplace platform. Sellers could create profiles and offer services, while buyers could search, contact, book, and pay online, as well as leave reviews. The system included an admin interface for approving sellers, monitoring transactions, handling disputes, and managing payouts. The platform was built using Node.js, MongoDB, Elasticsearch, and Angular, with integration for email, SMS, and telephony services, and was optimized for both desktop and mobile devices.
+
+### Accurate Autonomous Landing System for [Multicopters](https://en.wikipedia.org/wiki/Multirotor)
+Developed a computer vision-based algorithm for accurately identifying a unique pattern on a ground base station, essential for autonomous multicopter landing. The algorithm was designed to be highly accurate, computationally efficient, real-time, and height-invariant. Implemented using OpenCV on an embedded Linux board, it enabled precise positional and orientational landing.
+
+### Double-Ratchet Secure Messaging System
+Defined the requirements for a secure messaging system, researched potential solutions, and selected, adapted, and integrated a double-ratchet messaging protocol into the client's application.
 
 ### Blockchain Customization
 Customized a proof-of-stake blockchain to meet client-specific requirements. This involved guiding multiple development teams, inexperienced in cryptocurrency, through the integration process. The new cryptocurrency successfully passed several rigorous security and functionality audits.
@@ -28,24 +58,3 @@ Developed a cryptocurrency exchange platform enabling secure, automated trading 
 
 ### Ethereum Token
 Created an Ethereum token tailored to the client's specifications and designed a smart contract for a trustless exchange of the token.
-
-### Double-Ratchet Secure Messaging System
-Defined the requirements for a secure messaging system, researched potential solutions, and selected, adapted, and integrated a double-ratchet messaging protocol into the client's application.
-
-### Accurate Autonomous Landing System for [Multicopters](https://en.wikipedia.org/wiki/Multirotor)
-Developed a computer vision-based algorithm for accurately identifying a unique pattern on a ground base station, essential for autonomous multicopter landing. The algorithm was designed to be highly accurate, computationally efficient, real-time, and height-invariant. Implemented using OpenCV on an embedded Linux board, it enabled precise positional and orientational landing.
-
-### Online Marketplace
-Developed a comprehensive two-sided online marketplace platform. Sellers could create profiles and offer services, while buyers could search, contact, book, and pay online, as well as leave reviews. The system included an admin interface for approving sellers, monitoring transactions, handling disputes, and managing payouts. The platform was built using Node.js, MongoDB, Elasticsearch, and Angular, with integration for email, SMS, and telephony services, and was optimized for both desktop and mobile devices.
-
-### SMS Sending API
-Developed a scalable SMS sending platform with a user-friendly API for a [Kannel](http://www.kannel.org/) server. The platform featured self-service capabilities, allowing users to subscribe, input payment details, and manage SMS campaigns. It also included an admin interface for monitoring system health and activity. Built using Node.js, MongoDB, and Angular.js, the platform supported millions of SMS messages for various marketing campaigns.
-
-### Angular.js Course
-Designed and instructed a comprehensive one-week Angular.js course, delivered multiple times to developers at [Pictet Private Bank](https://www.group.pictet/) and other front-end developers in Geneva, Switzerland.
-
-### Flash-Card Based Spaced Repetition Tool for Memorization
-Developed a user-friendly Facebook app to create and practice flashcards using the [spaced repetition](https://www.supermemo.com/english/ol/sm2.htm) algorithm to optimize learning.
-
-### Real-Time Apache Kafka Visualization
-Created a tool to visualize real-time, high-throughput data streams, aggregate statistics, and provide real-time search capabilities, using Node.js, Angular.js, Socket.io, and Apache Kafka.


### PR DESCRIPTION
## Summary
- Rewrites `about.md` around AI/ML, distributed systems, cloud architecture, and blockchain consulting
- Expands `portfolio.md` with three new projects (Apache Iceberg deployment, Apache Flink data pipeline, database lineage algorithm) and adds Dean's List note to education

## Test plan
- [ ] Verify pages render correctly on the Jekyll site
- [ ] Confirm navigation links to /about/ and /portfolio/ still work
- [ ] Check that no external/internal links are broken


---
_Generated by [Claude Code](https://claude.ai/code/session_012CzDumG7SUbTsrWrnG5Mjn)_