### PR TITLE
Improve homepage SEO: tags, intro copy, canonical URL, sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,11 +9,13 @@
 title: Itamar Weiss
 email: me@itamarweiss.com
 description: > # this means to ignore newlines until "baseurl:"
-  Personal blog by Itamar Weiss.
+  Notes on AI agents, data platforms, software engineering, and production systems by Itamar Weiss.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://www.itamarweiss.com" # the base hostname & protocol for your site
+url: "https://www.itamar-weiss.com" # the base hostname & protocol for your site
 twitter_username: itamarwe
 github_username:  itamarwe
 
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-sitemap

--- a/index.html
+++ b/index.html
@@ -6,7 +6,12 @@ excerpt: "Helping teams ship AI agents, data platforms, and production AI featur
 
 <div class="home">
 
-  <h1 class="page-heading">Posts</h1>
+  <header class="home-intro">
+    <h1 class="post-title">Itamar Weiss — Hands-on AI &amp; Data Consultant</h1>
+    <p>I help teams design and ship AI agents, data platforms, and production AI features. I write about AI systems, software engineering, data infrastructure, drones, and the practical work of turning technical ideas into reliable products.</p>
+  </header>
+
+  <h2 class="page-heading">Latest Writing</h2>
 
   <ul class="post-list">
     {% for post in site.posts %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.itamar-weiss.com/sitemap.xml


### PR DESCRIPTION
## Why

Google's homepage snippet was still showing "Personal blog by Itamar Weiss." — generic, and not reflecting what the about page actually describes. The cause was a mix of: no above-the-fold copy on the homepage, that exact string baked into the footer via `site.description`, and no sitemap/robots.txt to help crawlers re-discover the site.

## What changed

**Homepage metadata (`index.html`)**
- Added a custom `title` and `excerpt` in frontmatter so `<title>` and `<meta description>` reflect the consulting work from `about.md` instead of the generic site fallback.
- Added a visible H1 intro and short paragraph above the post list so the page actually says what it's about. Renamed the post-list heading from `Posts` to `Latest Writing`.

**Shared head (`_includes/head.html`)**
- Added `author`, Open Graph (`og:title`, `og:description`, `og:url`, `og:type`, `og:image`, `og:site_name`), and Twitter Card tags. `og:type` is `article` for posts and `website` otherwise. All reuse the same title/description variables.

**Site config (`_config.yml`)**
- Rewrote `site.description` (also used by the footer) from "Personal blog by Itamar Weiss." to something keyword-rich and accurate.
- **Bug fix:** `site.url` was `http://www.itamarweiss.com` (no hyphen, http), but the `CNAME` is `www.itamar-weiss.com`. Every canonical and OG URL was pointing at the wrong domain. Corrected to `https://www.itamar-weiss.com`.
- Enabled `jekyll-sitemap` (already bundled with the `github-pages` gem) so `/sitemap.xml` is generated.

**`robots.txt`** (new) — allows all crawlers and points to the sitemap.

## Verify after deploy

- [ ] `https://www.itamar-weiss.com/` shows the new intro and "Latest Writing" heading.
- [ ] View source: `<title>`, `<meta description>`, `og:*`, and `<link rel="canonical">` reflect the new copy and the correct hyphenated HTTPS domain.
- [ ] `https://www.itamar-weiss.com/sitemap.xml` returns 200 and contains entries for posts + pages.
- [ ] `https://www.itamar-weiss.com/robots.txt` returns 200.
- [ ] In Google Search Console: submit the sitemap, then Request Indexing on the homepage. Snippets typically take days to weeks to refresh.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYzKGRLGm9VAp65YWWQSGk)_