### PR TITLE
Add GA4 + site backlink to the embedded apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ How it is wired:
 - `next.config.ts` rewrites `/photo-geolocation/` to the app's `index.html`,
   and `app/sitemap.ts` lists the URL.
 
+Both embedded apps (`/photo-geolocation/` and `/solar-system/`) link back to the
+site root and report to the same GA4 property as the rest of the site. Because
+they are static HTML — not rendered by Next — the `<Analytics />` component
+doesn't reach them; instead `scripts/inject-ga.mjs` runs during the root build
+and stamps the gtag snippet into each app's `index.html` using
+`NEXT_PUBLIC_GA_ID`. When that var is unset (typical local build) it's a no-op,
+so committed files stay clean and analytics only ships from Vercel.
+
 To work on the app on its own:
 
 ```bash

--- a/apps/photo-geolocation/src/v1/App.jsx
+++ b/apps/photo-geolocation/src/v1/App.jsx
@@ -15,6 +15,7 @@ export default function App() {
   return (
     <div className={styles.shell}>
       <header className={styles.header}>
+        <a className={styles.link} href="/" title="Back to itamarweiss.com">← itamarweiss.com</a>
         <span className={styles.logo}>📍 GeoPhoto Tool</span>
         <span className={styles.subtitle}>Tel Aviv photo geolocation</span>
         <span className={styles.badges}>

--- a/apps/photo-geolocation/src/v1/App.module.css
+++ b/apps/photo-geolocation/src/v1/App.module.css
@@ -49,6 +49,12 @@
 
 .link {
   color: var(--text-muted);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 .active {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Personal blog of Itamar Weiss — Next.js / Vercel.",
   "scripts": {
     "dev": "next dev",
-    "build": "npm run build:photo-geolocation && next build",
+    "build": "npm run build:photo-geolocation && node scripts/inject-ga.mjs && next build",
     "build:photo-geolocation": "cd apps/photo-geolocation && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci --include=dev --no-audit --no-fund && npm run build",
     "start": "next start",
     "lint": "next lint"

--- a/public/solar-system/index.html
+++ b/public/solar-system/index.html
@@ -59,6 +59,7 @@
   <script type="module" crossorigin src="./assets/index-CqkC38YO.js"></script>
 </head>
 <body>
+  <a id="site-backlink" href="/" title="Back to itamarweiss.com" style="position:absolute;top:10px;right:10px;z-index:10;color:#fff;background-color:rgba(0,0,0,0.5);padding:6px 10px;border-radius:5px;font-family:Arial,sans-serif;font-size:13px;text-decoration:none;">← itamarweiss.com</a>
   <div id="info">
     <h2>Sun-Earth Simulation</h2>
     <p>Demonstrating day/night transitions</p>

--- a/scripts/inject-ga.mjs
+++ b/scripts/inject-ga.mjs
@@ -1,0 +1,47 @@
+// Inject the GA4 (gtag.js) snippet into the embedded static apps' index.html
+// at build time, using the same NEXT_PUBLIC_GA_ID the Next site uses, so
+// /solar-system/ and /photo-geolocation/ report to the same GA4 property.
+//
+// These apps are plain static HTML served from public/ — they are NOT rendered
+// by Next, so the <Analytics /> component in app/layout.tsx never touches them.
+//
+// Behaviour mirrors components/Analytics.tsx: when NEXT_PUBLIC_GA_ID is unset
+// (e.g. local `npm run build` without the env var exported), this is a no-op,
+// so no analytics is emitted and committed files aren't modified. On Vercel the
+// var is a real environment variable, so the snippet is injected into the build.
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+
+const gaId = process.env.NEXT_PUBLIC_GA_ID
+if (!gaId) {
+  console.log('[inject-ga] NEXT_PUBLIC_GA_ID not set — skipping analytics injection.')
+  process.exit(0)
+}
+
+const MARKER = '<!-- ga4 (injected by scripts/inject-ga.mjs) -->'
+const snippet = `${MARKER}
+    <script async src="https://www.googletagmanager.com/gtag/js?id=${gaId}"></script>
+    <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaId}');</script>`
+
+const targets = [
+  'public/solar-system/index.html',
+  'public/photo-geolocation/index.html',
+]
+
+for (const file of targets) {
+  if (!existsSync(file)) {
+    console.log(`[inject-ga] ${file} not found — skipping.`)
+    continue
+  }
+  let html = readFileSync(file, 'utf8')
+  if (html.includes(MARKER)) {
+    console.log(`[inject-ga] ${file} already has the tag — skipping.`)
+    continue
+  }
+  if (!html.includes('</head>')) {
+    console.warn(`[inject-ga] ${file} has no </head> — skipping.`)
+    continue
+  }
+  html = html.replace('</head>', `    ${snippet}\n  </head>`)
+  writeFileSync(file, html)
+  console.log(`[inject-ga] injected GA4 (${gaId}) into ${file}`)
+}


### PR DESCRIPTION
## Summary

Adds GA4 analytics and a "back to site" link to the two embedded static apps (`/solar-system/` and `/photo-geolocation/`).

> **Stacked on #38.** Base is `claude/photo-geolocation-app`, so the diff here is just the GA4/backlink commit. Merge #38 first; this targets `master` automatically once #38 lands (or rebase onto `master` after).

## GA4 on both embedded apps

These apps are static HTML served from `public/`, so the Next `<Analytics />` component never reaches them. New `scripts/inject-ga.mjs` runs during the root build and stamps the standard gtag snippet into each app's `index.html` using the existing **`NEXT_PUBLIC_GA_ID`** — so both report to the **same GA4 property** as the rest of the site, with no hardcoded ID.

- Build chain: `build:photo-geolocation` → `inject-ga` → `next build`.
- **No-op when `NEXT_PUBLIC_GA_ID` is unset** (typical local build), so committed files stay clean and analytics only ships from Vercel. Idempotent (won't double-inject).

## Backlink to the site root

A `← itamarweiss.com` link (`href="/"`) on both apps:
- photo-geolocation: in the app header (with hover state).
- solar-system: top-right overlay (its other corners were occupied).

## Verification

- Injection tested on temp copies: injects once into both files, idempotent on re-run, no-op without the env var.
- Full `npm run build` passes; with no env var the committed `solar-system/index.html` gains **only** the backlink (no gtag).
- `next start` + curl: `/solar-system/` → 200 with the backlink, `/photo-geolocation/` → 200; geo backlink confirmed in the JS bundle.

Note: solar-system's source lives in a separate repo, so its GA is build-injected (keeps the committed file clean); its backlink is committed directly.

https://claude.ai/code/session_01YPcua3ct4Cq3NdwzwszAHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPcua3ct4Cq3NdwzwszAHJ)_