### PR TITLE
Reframe drone post from "hearing" to "detecting"

### DIFF
--- a/content/posts/2026-06-09-designing-a-mic-array-for-acoustic-drone-detection.md
+++ b/content/posts/2026-06-09-designing-a-mic-array-for-acoustic-drone-detection.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Designing a Microphone Array to Hear FPV Drones"
+title: "Designing a Microphone Array to Detect FPV Drones"
 comments: true
 date: 2026-06-09
 categories: drones
@@ -12,7 +12,7 @@ categories: drones
 @media (max-width: 600px) { .viz-frame { aspect-ratio: 3/4; } }
 </style>
 
-You can hear an FPV drone before you can see it. The motors and props throw off a
+You can detect an FPV drone before you can see it. The motors and props throw off a
 characteristic whine — a blade-pass fundamental and its harmonics — sitting right
 in the **300–4000 Hz** band. So a natural question: if I wanted to *detect* and
 *classify* drones acoustically with a small array of microphones, **what shape
@@ -228,5 +228,5 @@ the band. The line is 1-D only and, at 1.2 m, fully ambiguous up high.
 The whole thing — the geometry library, the response-curve simulations, and the
 manim animations above — is a couple hundred lines of Python. The physics is old
 (spatial Nyquist, aperiodic phased arrays from the acoustic-camera world); the new
-part is realizing that when a 16-channel network is doing the listening, the right
+part is realizing that when a 16-channel network is doing the detection, the right
 objective isn't a pretty beam, it's **baseline diversity**.


### PR DESCRIPTION
The acoustic FPV-drone post is about *detecting* drones, not "hearing" them. This updates the framing in the three spots that used hear/listen language (a follow-up to #43, which merged without this fix):

- **Title:** "Designing a Microphone Array to **Detect** FPV Drones"
- **Opening line:** "You can **detect** an FPV drone before you can see it."
- **Closing line:** "...when a 16-channel network is doing the **detection**..."

3 insertions, 3 deletions. `next build` passes.

https://claude.ai/code/session_01RWLv9458D6QzcyNq1JLaG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWLv9458D6QzcyNq1JLaG2)_