### PR TITLE
Add circular-aperiodic geometry to the interactive explorers

### DIFF
--- a/public/mic-array-viz/beam.html
+++ b/public/mic-array-viz/beam.html
@@ -62,6 +62,9 @@
     import { CSS2DRenderer, CSS2DObject } from "three/addons/renderers/CSS2DRenderer.js";
 
     const C_SOUND = 343, GOLD = Math.PI * (3 - Math.sqrt(5)), M = 16;
+    // Fixed angular jitter (numpy RandomState(3)) so the ring matches the study.
+    const JIT = [0.1016, 0.4163, -0.4182, 0.0217, 0.7859, 0.7926, -0.7488, -0.5855,
+                 -0.8971, -0.1184, -0.9402, -0.0863, 0.2983, -0.4430, 0.3525, 0.1817];
 
     // ---- geometries (positions in metres, (x,y,z)) --------------------------
     const geos = {
@@ -69,6 +72,9 @@
         [(-ap/2) + ap*i/(M-1), 0, 0]),
       "UCA": (ap) => Array.from({length: M}, (_, i) => {
         const a = i*2*Math.PI/M, R = ap/2; return [R*Math.cos(a), R*Math.sin(a), 0]; }),
+      "Circular aperiodic": (ap) => Array.from({length: M}, (_, i) => {
+        const R = ap/2, a = (i + 0.5*JIT[i]) * 2*Math.PI/M;
+        return [R*Math.cos(a), R*Math.sin(a), 0]; }),
       "Spiral": (ap) => Array.from({length: M}, (_, i) => {
         const R = ap/2, r = R*Math.sqrt((i+0.5)/M), th = i*GOLD;
         return [r*Math.cos(th), r*Math.sin(th), 0]; }),

--- a/public/mic-array-viz/coarray.html
+++ b/public/mic-array-viz/coarray.html
@@ -59,9 +59,13 @@
     import { CSS2DRenderer, CSS2DObject } from "three/addons/renderers/CSS2DRenderer.js";
 
     const GOLD = Math.PI*(3-Math.sqrt(5)), M = 16;
+    // Fixed angular jitter (numpy RandomState(3)) so the ring matches the study.
+    const JIT = [0.1016, 0.4163, -0.4182, 0.0217, 0.7859, 0.7926, -0.7488, -0.5855,
+                 -0.8971, -0.1184, -0.9402, -0.0863, 0.2983, -0.4430, 0.3525, 0.1817];
     const geos = {
       "ULA": (ap)=>Array.from({length:M},(_,i)=>[(-ap/2)+ap*i/(M-1),0,0]),
       "UCA": (ap)=>Array.from({length:M},(_,i)=>{const a=i*2*Math.PI/M,R=ap/2;return[R*Math.cos(a),R*Math.sin(a),0];}),
+      "Circular aperiodic": (ap)=>Array.from({length:M},(_,i)=>{const R=ap/2,a=(i+0.5*JIT[i])*2*Math.PI/M;return[R*Math.cos(a),R*Math.sin(a),0];}),
       "Spiral": (ap)=>Array.from({length:M},(_,i)=>{const R=ap/2,r=R*Math.sqrt((i+0.5)/M),th=i*GOLD;return[r*Math.cos(th),r*Math.sin(th),0];}),
       "Nested dome": (ap)=>nestedDome(ap),
     };


### PR DESCRIPTION
Following the "how would a circular aperiodic array compare?" question, this adds it as a selectable geometry in both interactive explorers so readers can compare it live.

**What it is:** all 16 mics on a single ring (full aperture) but at jittered, non-uniform angles. The fixed jitter pattern matches the study's perturbed-uniform ring.

**How it compares (from the sim, now reproduced live in the explorer stats):**
- UCA-class **resolution** (every mic at max radius): 12° beamwidth @3 kHz at 40 cm, 4° at 120 cm — sharper than spiral/nested.
- UCA's discrete grating lobes dissolve into a low diffuse floor; co-array jumps from 8 → ~95–110 distinct baselines.
- Cost: all-on-the-rim can't guarantee tiny baselines, so the high-frequency floor rises at large aperture (−3.5 dB PSL @3 kHz, alias-free only to ~3.2 kHz at 120 cm). Still planar (no elevation).

Verified the JS reproduces the Python numbers exactly (120 cm: 4°, −3.5 dB, 3.2 kHz, 110 distinct) and screenshotted both explorers headless on the new option.

Analysis-only addition to the explorers; I did not touch the static recommendation chart (to avoid colliding with PR #46). Say the word if you'd also like it as a curve there.

https://claude.ai/code/session_01RWLv9458D6QzcyNq1JLaG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWLv9458D6QzcyNq1JLaG2)_