### PR TITLE
Add Iceberg optimization research playbook

### DIFF
--- a/research/iceberg-optimization/01-methodology-and-analysis.md
+++ b/research/iceberg-optimization/01-methodology-and-analysis.md
@@ -1,0 +1,433 @@
+# Part I — Methodology & Analysis
+
+> Optimize from evidence, not vibes. Every knob in Part II is downstream of a
+> fact you can measure. This chapter is how you gather those facts.
+
+The mistake most teams make is starting from the answer ("we should compact" /
+"we should partition by day") instead of the workload. Iceberg gives you an
+unusually rich, queryable record of how a table behaves — its metadata tables
+expose every file, partition, snapshot, and delete — and the engines that read
+and write it keep logs. Combine those with what users actually need, and the
+right settings mostly fall out.
+
+The workflow has five stages:
+
+```
+                          ┌─────────────────────────────────────────┐
+                          │  0. Frame: what is this table FOR?        │
+                          │     (workload taxonomy)                   │
+                          └───────────────────┬───────────────────────┘
+                                              │
+        ┌──────────────┬─────────────────────┼────────────────────┬──────────────┐
+        ▼              ▼                     ▼                    ▼              ▼
+  1. Query logs   2. Table metadata   3. Ingestion logs   4. User interviews
+  (how it's read) (current physical   (how it's written)  (requirements &
+                   layout & health)                        future read paths)
+        └──────────────┴─────────────────────┬────────────────────┴──────────────┘
+                                              ▼
+                          ┌─────────────────────────────────────────┐
+                          │  5. Synthesize → Optimization Profile     │
+                          │     → feeds Part II recommendations       │
+                          └─────────────────────────────────────────┘
+```
+
+Stages 1–4 are independent — run them in parallel — but they cross-check each
+other. Query logs tell you what *should* be cheap; metadata tells you why it
+*isn't*; ingestion logs tell you what *created* the problem; interviews tell you
+what's about to change. A recommendation supported by only one stream is a guess;
+one supported by three is a decision.
+
+---
+
+## Stage 0 — Frame the table: the workload taxonomy
+
+Before measuring anything, classify the table. The classification narrows the
+search space for every later decision. Five axes matter:
+
+| Axis | Buckets | Why it drives optimization |
+|---|---|---|
+| **Read pattern** | Point lookups · selective range scans · full scans/aggregations · ML feature reads | Decides partitioning + sort/cluster keys and COW-vs-MOR. |
+| **Write pattern** | Append-only · upsert/CDC · overwrite/backfill · slowly-changing | Decides write distribution, MOR vs COW, commit cadence. |
+| **Latency SLA** | Real-time (sec) · near-real-time (min) · batch (hourly/daily) | Trades small files & MOR (low latency) against read cost. |
+| **Mutability** | Immutable facts · mutable dimensions · GDPR/delete-heavy | Decides delete strategy and compaction frequency. |
+| **Scale & growth** | Rows/day, total size, partition cardinality, retention | Decides partition granularity and maintenance budget. |
+
+A *clickstream events* table (append-only, full-scan analytics, batch, immutable,
+huge) lands in a completely different corner of Part II than a *customer
+dimension* (upsert, point-lookup, near-real-time, mutable, small). Write the
+bucket down for each axis — it's the first line of the profile.
+
+---
+
+## Stage 1 — Query log analysis (how the table is read)
+
+**Goal:** learn the real predicates, the columns that filter, the join keys, the
+selectivity, and which queries are slow and why. This is the single most
+important input to *layout* decisions (partitioning, sort order, clustering).
+
+### Where the logs live
+
+| Platform | Source of truth |
+|---|---|
+| Snowflake | `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY` + `ACCESS_HISTORY` (column-level) |
+| Databricks | `system.query.history`, `system.access.column_lineage`, query profiles |
+| Trino/Starburst | event listener → query-events table; `EXPLAIN ANALYZE` |
+| Spark | Spark SQL UI / event logs (`spark.eventLog`), `EXPLAIN FORMATTED` |
+| Flink | Flink SQL plans (less relevant — Flink is usually the writer) |
+| dbt | `manifest.json` + `run_results.json`; warehouse query history for the compiled SQL |
+
+### What to extract
+
+For every recurring query against the table, capture:
+
+1. **Filter columns and operators** — `WHERE event_date >= … AND country = …`.
+   Tally frequency per column. *The most-filtered columns are your partition and
+   sort candidates.*
+2. **Filter selectivity** — what fraction of rows/partitions survive each
+   predicate. High-selectivity equality filters (e.g. `user_id = …`) want
+   sort/cluster locality, not partitioning (too high cardinality to partition on).
+3. **Join keys** — columns repeatedly joined want clustering so the engine reads
+   contiguous files.
+4. **Projected columns** — which columns are actually `SELECT`ed. Wide tables
+   read narrowly benefit from column-level layout and from *not* over-indexing on
+   unread columns.
+5. **Scan volume vs returned volume** — the ratio (bytes scanned / bytes
+   returned) is the headline inefficiency metric. A query that scans 2 TB to
+   return 10 MB is a pruning failure.
+6. **Time-of-day / concurrency** — when reads spike, so you can schedule
+   maintenance in the troughs.
+
+### The pruning diagnosis
+
+The core question for read optimization is **"is the engine pruning?"** Pull the
+query profile / `EXPLAIN ANALYZE` and read three numbers:
+
+- **files scanned vs files matched** — if a query that filters one day reads the
+  whole table, partitioning/clustering isn't aligned to the predicate, or the
+  predicate can't be pushed down (e.g. a function wrapping the column, or a type
+  mismatch defeating partition transforms).
+- **delete files applied per scan** — high counts on a MOR table mean read
+  amplification from accumulated deletes → a compaction signal, not a layout one.
+- **manifest scan time** — large planning time before any data is read points at
+  *metadata* bloat (too many manifests/snapshots), addressed in maintenance.
+
+> Example signal → implication: 80% of queries filter `event_date` and 30% also
+> filter `tenant_id`; lookups by `user_id` are frequent but `user_id` has
+> millions of distinct values. → **Partition by `day(event_date)`** (low
+> cardinality, near-universal filter), **sort/cluster by `tenant_id, user_id`**
+> (locality without partition explosion). Do *not* partition by `user_id`.
+
+A reusable Snowflake query-history starting point (real, runnable):
+
+```sql
+-- Most-filtered tables and the columns queried against an Iceberg table,
+-- last 30 days. Pair with ACCESS_HISTORY for column-level filter attribution.
+select  query_type,
+        count(*)                                   as execs,
+        avg(bytes_scanned)/1e9                      as avg_gb_scanned,
+        avg(rows_produced)                          as avg_rows_out,
+        avg(bytes_scanned) / nullif(avg(rows_produced),0) as scan_per_row,
+        avg(partitions_scanned)                     as avg_parts_scanned,
+        avg(partitions_total)                       as avg_parts_total
+from    snowflake.account_usage.query_history
+where   start_time > dateadd('day', -30, current_timestamp())
+  and   query_text ilike '%<schema>.<table>%'
+group by 1
+order by avg_gb_scanned desc;
+```
+
+The `partitions_scanned / partitions_total` ratio is the pruning score: close to
+1.0 means no pruning is happening.
+
+---
+
+## Stage 2 — Table metadata analysis (the current physical layout)
+
+**Goal:** measure the table's *current* health and layout directly from Iceberg's
+own metadata. This is unique to Iceberg — you don't have to guess, you can
+`SELECT`. Everything here is engine-agnostic; the metadata tables are part of the
+spec and exposed by Spark, Trino, Dremio, Snowflake, Athena, PyIceberg, etc.
+
+### The metadata tables you'll use
+
+| Metadata table | Tells you |
+|---|---|
+| `<table>.files` (`data_files` / `delete_files`) | Every file: size, record count, partition, column-level value bounds, null counts. |
+| `<table>.partitions` | Per-partition file count, record count, total size, delete-file count. |
+| `<table>.snapshots` | Commit history: timestamp, operation, added/deleted files & records, summary. |
+| `<table>.history` | Lineage of snapshots and which are current/ancestors. |
+| `<table>.manifests` | Manifest files and how many data files each tracks. |
+| `<table>.metadata_log_entries` | Successive `metadata.json` versions (metadata growth). |
+| `<table>.refs` | Branches and tags (WAP, time-travel anchors). |
+| `<table>.all_entries` | Low-level manifest entries (advanced debugging). |
+
+### The five health checks
+
+**1. File-size distribution (the small-file problem).** The most common pathology.
+
+```sql
+-- Spark/Trino. Buckets the data files of a table by size.
+select case
+         when file_size_in_bytes <  8*1024*1024  then '  <8MB (tiny)'
+         when file_size_in_bytes < 32*1024*1024  then ' 8-32MB (small)'
+         when file_size_in_bytes <128*1024*1024  then '32-128MB (ok)'
+         when file_size_in_bytes <512*1024*1024  then '128-512MB (good)'
+         else '>512MB (large)'
+       end                                   as bucket,
+       count(*)                              as files,
+       round(sum(file_size_in_bytes)/1e9, 2) as gb,
+       round(avg(record_count))              as avg_rows
+from   db.schema.table.files
+where  content = 0            -- data files only
+group by 1 order by 1;
+```
+
+If most files are `<32 MB`, query planning and open cost dominate → compaction +
+a write-side fix. The target band is **128–512 MB** (see Part II for the exact
+property).
+
+**2. Partition skew & cardinality.**
+
+```sql
+select  partition,
+        count(*)                              as files,
+        sum(record_count)                     as rows,
+        round(sum(file_size_in_bytes)/1e9, 2) as gb
+from    db.schema.table.partitions
+order by gb desc;
+```
+
+Look for: (a) thousands of partitions with a handful of tiny files each
+(over-partitioning); (b) a few partitions holding most of the data (skew — the
+partition key doesn't spread writes); (c) huge partition *count* relative to the
+predicates in Stage 1 (partitioned on a column nobody filters).
+
+**3. Delete-file accumulation (MOR read amplification).**
+
+```sql
+select  count(*)                              as delete_files,
+        round(sum(file_size_in_bytes)/1e6, 1) as mb,
+        sum(record_count)                     as deleted_rows
+from    db.schema.table.files
+where   content in (1,2);     -- 1=position deletes, 2=equality deletes
+```
+
+Compare delete-file count and rows to live data files. A high ratio means every
+read pays a merge tax → compaction (which re-applies and drops deletes) is
+overdue, and you may need to switch delete strategy or COW/MOR.
+
+**4. Snapshot & metadata growth.**
+
+```sql
+select  count(*)                                   as snapshots,
+        min(committed_at)                          as oldest,
+        max(committed_at)                          as newest,
+        datediff('day', min(committed_at), max(committed_at)) as span_days
+from    db.schema.table.snapshots;
+```
+
+Thousands of retained snapshots (especially from a high-frequency streaming
+writer) bloat `metadata.json` and slow planning → snapshot expiration. Also check
+`metadata_log_entries` row count and `manifests` count.
+
+**5. Manifest fragmentation.**
+
+```sql
+select  count(*)                                 as manifests,
+        round(avg(added_data_files_count +
+                  existing_data_files_count))    as avg_files_per_manifest,
+        sum(added_data_files_count +
+            existing_data_files_count)           as total_tracked_files
+from    db.schema.table.manifests;
+```
+
+Many manifests each tracking few files (the signature of frequent small commits)
+→ `rewrite_manifests`.
+
+> Metadata analysis tells you **what is wrong now**; query logs tell you **whether
+> it matters** for how the table is read. A table with 50k tiny files that is only
+> ever read by a nightly full scan is less urgent than one with 5k tiny files hit
+> by thousands of selective lookups.
+
+---
+
+## Stage 3 — Ingestion log analysis (how the table is written)
+
+**Goal:** understand the write side, because *most physical problems are created
+at write time* and the cheapest fix is usually to stop creating them rather than
+to clean up after.
+
+### Where the logs live
+
+| Writer | Source of truth |
+|---|---|
+| Spark batch | Spark event logs, job run history, number of write tasks/partitions. |
+| Flink | Checkpoint interval & history, committer logs, files-per-commit. |
+| NiFi | `PutIceberg` provenance events, batch sizes, flowfile cadence. |
+| Kafka Connect (Iceberg sink) | Connector commit interval, tasks, records/commit. |
+| dbt | `run_results.json` timings; whether models full-refresh or merge. |
+| Snowpipe / Snowflake | `COPY_HISTORY`, pipe usage, `INSERT`/`MERGE` history. |
+
+### What to extract
+
+The `<table>.snapshots` metadata table *is* an ingestion log — every commit is a
+row, and `summary` carries `added-data-files`, `added-records`,
+`added-files-size`, and the engine. Mine it:
+
+```sql
+-- Commit cadence and per-commit file production over the last 7 days.
+select  date_trunc('hour', committed_at)            as hr,
+        count(*)                                    as commits,
+        sum(cast(summary['added-data-files'] as int))   as files_added,
+        sum(cast(summary['added-records']    as bigint))as rows_added,
+        round(sum(cast(summary['added-files-size'] as bigint))
+              / nullif(sum(cast(summary['added-data-files'] as int)),0)
+              / 1e6, 1)                              as avg_added_file_mb
+from    db.schema.table.snapshots
+where   committed_at > current_timestamp - interval '7' day
+group by 1 order by 1;
+```
+
+Read it for:
+
+1. **Commit frequency** — a Flink job checkpointing every 30 s makes 2,880
+   commits/day, each producing ≥1 file *per partition written*. This is the #1
+   small-file generator. → tune checkpoint/commit interval, or accept it and lean
+   on compaction.
+2. **Files per commit vs partitions touched** — if each commit writes a file to
+   many partitions (fanout), the small-file problem multiplies by partition
+   count. → write distribution mode (`hash`/`range`) or pre-shuffle.
+3. **Average added-file size** — directly comparable to the 128–512 MB target.
+   Tiny added files = the write is the problem, not just history.
+4. **Operation mix** — ratio of `append` vs `overwrite` vs `delete`. Lots of
+   `delete`/`overwrite` (CDC) flags the COW/MOR decision and delete-file growth.
+5. **Backfills/full-refresh** — large `overwrite` snapshots that rewrite whole
+   partitions; coordinate these with maintenance windows.
+6. **Failed/retried commits** — commit conflicts (multiple writers) show as
+   retries; orphan files are their residue. → concurrency settings + orphan
+   cleanup.
+
+> Cross-check with Stage 2: if `files` shows 40k tiny files and `snapshots` shows
+> a 30 s commit cadence with ~13 files/commit, you've found the cause. The fix is
+> ingestion-side (Part II ch. 3) first, maintenance (ch. 4) second.
+
+---
+
+## Stage 4 — User interviews (data-access requirements)
+
+**Goal:** capture what logs can't — intent, future workloads, and the
+cost/latency/freshness tradeoffs only humans can rank. Logs are a rear-view
+mirror; interviews are the windshield. A layout optimized purely on history will
+be wrong the moment a new dashboard ships.
+
+Interview the **consumers** (analysts, BI owners, ML/data-science, downstream
+pipeline owners) and the **producers** (the team running ingestion). A compact
+question set, grouped by what it unlocks:
+
+**Access patterns & filters**
+- "When you query this, what do you almost always filter by?" (confirms/long-tails
+  the Stage 1 partition/sort candidates — and surfaces *planned* filters not yet
+  in the logs).
+- "Point lookups, dashboards, or big scans? Roughly what split?"
+- "Which columns do you actually need? Any you never use?"
+
+**Freshness & latency**
+- "How fresh does this need to be — seconds, minutes, hours?" (sets the ingestion
+  latency SLA and therefore the small-file/MOR tolerance).
+- "What's an acceptable query latency at p95?"
+
+**Mutability & correctness**
+- "Do records get updated or deleted after they land? How often, by what key?"
+  (drives COW vs MOR and delete strategy).
+- "Do you need time travel / as-of queries? How far back?" (sets snapshot
+  retention — overrides aggressive expiration).
+- "Any GDPR/right-to-erasure obligations?" (forces delete capability + retention
+  limits).
+
+**Cost & ownership**
+- "Who pays for compute, and is this cost- or latency-sensitive?" (ranks the
+  speed-vs-cost knobs, e.g. `write.distribution-mode=none` for cheap fast writes
+  vs `hash` for read-optimized layout).
+- "What's changing in the next two quarters?" (new consumers, schema evolution,
+  volume growth — pre-empts re-partitioning churn).
+
+The deliverable of this stage is a short **requirements memo** per table:
+SLA (freshness, p95 latency), retention/time-travel window, mutability profile,
+top filter columns (confirmed by a human), and cost posture. These become hard
+constraints that can *override* a log-derived recommendation — e.g. logs say
+"expire snapshots after 1 day" but compliance needs 90-day time travel.
+
+---
+
+## Stage 5 — Synthesis: the Optimization Profile
+
+Collapse the four streams into one structured profile per table. This is the
+single artifact that Part II consumes. Resolve conflicts with this precedence:
+
+1. **Hard requirements** (compliance, SLA, time-travel) from interviews — never
+   violated.
+2. **Read evidence** (query logs) — primary driver of *layout* (partition, sort,
+   COW/MOR).
+3. **Write evidence** (ingestion logs) — primary driver of *ingestion* settings
+   and the *root cause* of file/metadata problems.
+4. **Current state** (metadata) — primary driver of *maintenance* (what to clean
+   up now) and the baseline you'll measure improvement against.
+
+### Profile template
+
+```yaml
+table: db.schema.events
+owner: growth-data
+# --- Stage 0: workload taxonomy ---
+read_pattern:   selective-range-scan        # + occasional full scan
+write_pattern:  append-only                  # CDC? no
+latency_sla:    near-real-time (~5 min)
+mutability:     immutable (GDPR delete only, by user_id)
+scale:          ~1.2B rows/day, 40 TB, retention 18 mo
+
+# --- Stage 1: read evidence ---
+top_filters:        [event_date (92%), tenant_id (34%), user_id (point lookups)]
+typical_selectivity: 1 day of N days; tenant high-selectivity
+join_keys:          [user_id]
+pruning_score:      poor (partitions_scanned/total ~0.8)   # not pruning
+
+# --- Stage 2: current state ---
+file_size_p50:      11 MB         # tiny → small-file problem
+partition_scheme:   day(event_date)/hour(event_date)   # over-partitioned (hour)
+delete_files:       low
+snapshots_retained: 9,400         # bloated
+manifests:          3,100 (avg 9 files each)   # fragmented
+
+# --- Stage 3: write evidence ---
+writer:             Flink
+commit_cadence:     ~30s checkpoints (2,880/day)
+files_per_commit:   ~13, avg 11 MB           # root cause of tiny files
+operation_mix:      99% append
+
+# --- Stage 4: requirements ---
+freshness:          5 min ok (NOT seconds)   # room to slow commits
+time_travel:        7 days
+cost_posture:       cost-sensitive
+
+# --- Stage 5: decisions (→ Part II) ---
+decisions:
+  table_properties: [ "partition: drop hour, keep day(event_date)",
+                      "sort/cluster by tenant_id,user_id",
+                      "target-file-size 256MB" ]
+  ingestion:        [ "raise Flink checkpoint to 2-5 min",
+                      "write.distribution-mode=hash on event_date" ]
+  maintenance:      [ "compact every 1-4h (bin-pack + sort)",
+                      "expire snapshots >7d",
+                      "rewrite_manifests weekly",
+                      "remove_orphan_files >3d" ]
+```
+
+With a filled profile, Part II is mostly lookup: each `decisions` line maps to a
+specific property, command, or platform feature in the next chapters.
+
+> **Iterate.** Optimization is a loop, not a one-shot. After applying Part II,
+> re-run Stages 1–3 and compare against the profile baseline (pruning score, file
+> p50, delete ratio, planning time). Keep the profile in version control next to
+> the table's definition so the *why* travels with the table.
+
+→ Continue to [Part II · Table-properties optimization](02-recommendations-table-properties.md).

--- a/research/iceberg-optimization/02-recommendations-table-properties.md
+++ b/research/iceberg-optimization/02-recommendations-table-properties.md
@@ -1,0 +1,243 @@
+# Part II · Chapter 2 — Table-properties optimization
+
+> These are the settings baked into the table definition. They govern *layout*
+> and *write behavior* and are the most leveraged decisions you make — they shape
+> every read and write that follows. Drive each one from the
+> [optimization profile](01-methodology-and-analysis.md#stage-5--synthesis-the-optimization-profile).
+
+The decisions, in dependency order: **partitioning → sort/cluster order → file
+size → write distribution → COW vs MOR → format/compression → metadata
+hygiene.** Earlier choices constrain later ones, so resolve them in that order.
+
+---
+
+## 2.1 Partitioning
+
+**What it does:** physically segregates files by a partition value so the engine
+can skip whole directories of files (partition pruning) when a query filters on
+that value. Iceberg's *hidden partitioning* applies a transform
+(`day`, `month`, `hour`, `bucket[N]`, `truncate[W]`, `identity`) to a column and
+tracks it in metadata — queries filter the raw column and pruning happens
+automatically, no extra predicate needed.
+
+**Drive it from:** Stage 1 top-filter columns + their cardinality, Stage 2
+partition skew, Stage 4 confirmed/planned filters.
+
+**Rules of thumb:**
+
+- Partition on the **most-filtered low-to-moderate-cardinality column**, almost
+  always **time** via a transform: `day(ts)` for most analytics, `hour(ts)` only
+  for very high-volume near-real-time tables, `month(ts)` for slow/archival.
+- **Match granularity to partition size, not to the calendar.** Aim for
+  partitions large enough to hold healthy files (hundreds of MB to a few GB).
+  Thousands of tiny partitions (the classic `hour` over a low-volume table) is
+  over-partitioning — it *causes* the small-file problem rather than helping.
+- **Never partition on a high-cardinality column** (`user_id`, `order_id`). Use
+  `bucket[N]` if you need to spread a high-cardinality key evenly
+  (`bucket(64, user_id)`), which caps the partition count at N while preserving
+  join/lookup locality.
+- A second partition field is justified only when a second column appears in a
+  large share of queries *and* keeps partitions healthily sized (e.g.
+  `day(event_date)` + `bucket(16, tenant_id)` for a multi-tenant table where most
+  queries are tenant-scoped).
+- **Don't partition on a column nobody filters** — it's pure overhead. Cross-check
+  the candidate against Stage 1 frequencies.
+
+**Partition evolution:** Iceberg can change the partition spec *without rewriting
+history* — old data keeps its old layout, new data uses the new spec, and split
+planning handles both. So an early wrong choice is recoverable: evolve the spec,
+then let compaction re-lay-out the hot/recent partitions. This is a major reason
+not to over-engineer partitioning up front.
+
+```sql
+ALTER TABLE db.events ADD PARTITION FIELD bucket(16, tenant_id);
+ALTER TABLE db.events DROP PARTITION FIELD hour(event_ts);   -- de-granularize
+```
+
+---
+
+## 2.2 Sort order & clustering
+
+**What it does:** orders rows *within* files (and across files written together)
+so that values of the sort columns are contiguous. This tightens the per-file
+min/max stats Iceberg stores, which powers **file-level and row-group skipping**
+for columns that are too high-cardinality to partition on. It also improves
+compression.
+
+**Drive it from:** Stage 1 high-selectivity equality/range filters and join keys
+that are *not* partition columns; Stage 2 "poorly colocated data" signal.
+
+**Rules of thumb:**
+
+- Set a **table sort order** so every writer (and compaction) maintains locality:
+  ```sql
+  ALTER TABLE db.events WRITE ORDERED BY tenant_id, user_id;
+  ```
+- **Linear sort** (`a, b, c`) when there's a clear primary filter column —
+  pruning is excellent on the leading column, weaker on later ones.
+- **Z-order** (multi-dimensional) when several columns are filtered with similar
+  frequency and no single one dominates. Z-order trades a little single-column
+  pruning for balanced multi-column pruning. Apply it at compaction time:
+  ```sql
+  CALL system.rewrite_data_files(
+    table => 'db.events',
+    strategy => 'sort',
+    sort_order => 'zorder(tenant_id, country)');
+  ```
+- Sorting is only *maintained* if writers respect it (cheap for batch, costly for
+  streaming) — for streaming tables it's common to write unsorted fast and
+  **restore sort during compaction** (see [maintenance](04-recommendations-maintenance.md)).
+- **Platform note:** on Databricks, **Liquid Clustering** supersedes both
+  partitioning and Z-order — you declare `CLUSTER BY` keys and the platform
+  maintains layout incrementally. On Snowflake-managed tables, a `CLUSTERING KEY`
+  drives automatic clustering. See the [platform playbooks](05-platform-playbooks.md).
+
+---
+
+## 2.3 Target file size
+
+**What it does:** `write.target-file-size-bytes` tells writers and compaction the
+size to aim for per data file. It's the central lever on the small-file problem.
+
+**Drive it from:** Stage 2 file-size distribution, Stage 0 read pattern, Stage 3
+writer type.
+
+**The guidance, with the nuance that matters:**
+
+- Iceberg's **default is 512 MB**. The widely-used safe band for analytical tables
+  is **128–512 MB**; **256 MB** is a good general default that balances pruning
+  granularity against read parallelism.
+- **Parallelism is driven by row-group size, not file size** — files are
+  splittable, row groups are not. So "bigger files = better" has limits: oversized
+  row groups cause memory pressure and spill at read time, and oversized files
+  slow compaction. Keep an eye on row-group size (`write.parquet.row-group-size-bytes`,
+  ~128 MB default) alongside file size.
+- **Lower the target (128–256 MB)** for: wide/nested tables, executors with
+  limited memory, engines that prefer smaller files, and **streaming tables**
+  where waiting to fill a 512 MB file would blow the latency SLA.
+- Some practitioners deliberately target **much smaller files** in specific
+  engines/workloads; treat that as an *engine-validated exception*, not the
+  default. Confirm with query plans (scan parallelism, spill), not just metadata.
+
+```sql
+ALTER TABLE db.events SET TBLPROPERTIES (
+  'write.target-file-size-bytes'='268435456'      -- 256 MB
+);
+```
+
+> The target *guides* but doesn't strictly enforce output size — record
+> boundaries, compression, and partition fan-out cause variation. Validate
+> against the Stage 2 distribution after a compaction cycle.
+
+---
+
+## 2.4 Write distribution mode
+
+**What it does:** `write.distribution-mode` controls whether the engine shuffles
+data before writing so that rows destined for the same partition land in the same
+task/file. It's the difference between "every task writes a sliver to every
+partition" (fan-out → many small files) and "each partition is written by one
+task" (fewer, larger files).
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| `none` | No shuffle; write as data arrives. Fast writes, **many small files** when tasks span partitions. | Latency-critical streaming where each task already targets one partition, or cost-sensitive writes you'll compact later. |
+| `hash` | Shuffle by hashed partition key; one task per partition. Fewer files. | The default choice for **partitioned batch** and most read-optimized tables. |
+| `range` | Range-partition the shuffle (also respects sort order). Best file sizing + global ordering, most expensive shuffle. | Sorted/Z-ordered tables where layout quality matters most. |
+
+**Drive it from:** Stage 3 fan-out (files-per-commit vs partitions-touched) and
+Stage 4 cost-vs-latency posture. High fan-out + read-optimized table → `hash` or
+`range`. Latency-critical + cost-sensitive → `none` + aggressive compaction.
+
+```sql
+ALTER TABLE db.events SET TBLPROPERTIES ('write.distribution-mode'='hash');
+```
+
+---
+
+## 2.5 Copy-on-Write vs Merge-on-Read
+
+**What it does:** decides *when* the cost of an update/delete is paid. This is set
+per operation: `write.update.mode`, `write.delete.mode`, `write.merge.mode`, each
+`copy-on-write` (default) or `merge-on-read`.
+
+- **COW** rewrites whole data files at write time with the change applied. Reads
+  are clean (no merge), writes are expensive. Best for **read-heavy, low-mutation**
+  tables and batch overwrites.
+- **MOR** writes small **delete files** (position or equality) and merges them at
+  read time. Writes are cheap and fast, reads pay a merge tax that **grows with
+  accumulated deletes**. Best for **high-frequency updates/CDC** and streaming.
+
+**Drive it from:** Stage 0 write pattern + mutability, Stage 3 operation mix,
+Stage 1 delete-files-per-scan, Stage 4 freshness SLA.
+
+```
+   write frequency of updates/deletes ──►
+   low                          high
+   ┌──────────────┬──────────────────────────┐
+   │   COW        │          MOR              │
+   │ (clean reads)│ (cheap writes + compact)  │
+   └──────────────┴──────────────────────────┘
+   read sensitivity ▲ favors COW   ▲ favors MOR + frequent compaction
+```
+
+**Delete-type sub-decision (MOR, spec v2):**
+
+- **Position deletes** — point at exact row positions; efficient to read, the
+  natural output of engines that know the row position (Flink, Spark MERGE). The
+  default and preferred type.
+- **Equality deletes** — match on column values; cheap to write (no need to find
+  the row), expensive to read. Common in CDC/upsert pipelines that don't know the
+  position. Accumulate fast → compact aggressively.
+
+> **Don't pick COW just to "avoid maintenance."** COW shifts cost to writes; on a
+> large, frequently-changed table that can be ruinous. The MOR read tax is real
+> but is *managed by compaction*, which re-applies deletes into clean base files.
+> Choose on workload, not as a maintenance shortcut.
+
+**Spec v3 (GA/preview across platforms in early 2026):** position deletes are
+superseded by **deletion vectors** (compact binary, one per data file, stored in
+Puffin files) — faster to apply, simpler retention. If your engine and catalog
+support v3, prefer it for MOR tables; it narrows the MOR read penalty
+substantially.
+
+---
+
+## 2.6 File format & compression
+
+- **Parquet** is the default and right answer for analytics (columnar, great
+  pushdown). ORC and Avro exist; Avro suits row-oriented/streaming-write cases but
+  is rarely the analytics choice.
+- **Compression** via `write.parquet.compression-codec`: **`zstd`** is the modern
+  default — better ratio than `snappy` at comparable speed, which means fewer
+  bytes scanned. `snappy` only if a downstream consumer mandates it.
+- Tune `write.parquet.row-group-size-bytes` (read parallelism unit, see §2.3) and
+  enable dictionary encoding (default) for low-cardinality string columns.
+- **Column-level stats:** Iceberg stores min/max/null/count per column up to
+  `write.metadata.metrics.max-inferred-column-defaults` (default 100 columns).
+  For very wide tables, queries filter on columns beyond that cutoff get no
+  skipping → set `write.metadata.metrics.column.<col>=full` for the columns that
+  actually filter (from Stage 1), and `none` for large free-text columns you never
+  filter (storing their min/max is wasted metadata).
+
+---
+
+## 2.7 Metadata-hygiene properties
+
+Set-and-forget knobs that keep metadata from bloating; complements the active
+work in [maintenance](04-recommendations-maintenance.md).
+
+| Property | Recommended | Why |
+|---|---|---|
+| `write.metadata.delete-after-commit.enabled` | `true` | Auto-expire old `metadata.json` files on commit. |
+| `write.metadata.previous-versions-max` | `50–100` | Cap retained `metadata.json` versions (pairs with above). |
+| `commit.retry.num-retries` | `4–10` (higher for multi-writer) | Survive optimistic-concurrency commit conflicts. |
+| `commit.retry.min-wait-ms` | tune up under contention | Backoff between retries. |
+| `history.expire.max-ref-age-ms` | set on non-`main` refs | Auto-expire stale **branches/tags** so they don't pin old snapshots/files. |
+| `write.spark.fanout.enabled` | `true` for unsorted streaming writes | Avoids per-partition sort buffering in fan-out writes (at the cost of more open files). |
+
+> Branches and tags **block snapshot expiration** by design — a forgotten WAP
+> branch or audit tag will silently prevent file cleanup. Audit `<table>.refs`
+> periodically and set `max-ref-age-ms` where appropriate.
+
+→ Continue to [Ingestion optimization](03-recommendations-ingestion.md).

--- a/research/iceberg-optimization/02-recommendations-table-properties.md
+++ b/research/iceberg-optimization/02-recommendations-table-properties.md
@@ -77,7 +77,11 @@ that are *not* partition columns; Stage 2 "poorly colocated data" signal.
   pruning is excellent on the leading column, weaker on later ones.
 - **Z-order** (multi-dimensional) when several columns are filtered with similar
   frequency and no single one dominates. Z-order trades a little single-column
-  pruning for balanced multi-column pruning. Apply it at compaction time:
+  pruning for balanced multi-column pruning. **But its locality decays with each
+  column you add, and it only helps queries that filter the clustered columns** —
+  don't Z-order "to be safe." For 2+ dimensions a **Hilbert** curve preserves
+  locality better than Z-order (the reason Databricks Liquid Clustering uses
+  Hilbert). Apply it at compaction time:
   ```sql
   CALL system.rewrite_data_files(
     table => 'db.events',
@@ -125,7 +129,10 @@ ALTER TABLE db.events SET TBLPROPERTIES (
 );
 ```
 
-> The target *guides* but doesn't strictly enforce output size — record
+> The target *guides* but doesn't strictly enforce output size — and writers
+> don't always honor it well (you can set 512 MB and still get ~100 MB files,
+> e.g. apache/iceberg #8729). **Verify actual output file sizes from the Stage 2
+> distribution after writing/compacting — don't assume the knob worked.** Record
 > boundaries, compression, and partition fan-out cause variation. Validate
 > against the Stage 2 distribution after a compaction cycle.
 

--- a/research/iceberg-optimization/03-recommendations-ingestion.md
+++ b/research/iceberg-optimization/03-recommendations-ingestion.md
@@ -1,0 +1,150 @@
+# Part II · Chapter 3 — Ingestion optimization
+
+> Most physical problems are *created at write time.* The cheapest small file is
+> the one you never wrote. This chapter is about shaping the write so the table
+> stays healthy without leaning entirely on after-the-fact maintenance. Drive it
+> from the [Stage 3 ingestion analysis](01-methodology-and-analysis.md#stage-3--ingestion-log-analysis-how-the-table-is-written).
+
+The single most important ingestion variable is **commit cadence**, because every
+Iceberg commit creates a snapshot and ≥1 file per partition written. Get that
+right and most other problems shrink.
+
+---
+
+## 3.1 Pick the ingestion model from the latency SLA
+
+| Model | Freshness | File/metadata pressure | Use when (Stage 4 SLA) |
+|---|---|---|---|
+| **Batch** | hours+ | Lowest — few big commits, idempotent, easy retries | Backfills, daily loads, slowly-changing data; predictability > speed. |
+| **Micro-batch** | minutes | Moderate — tune the interval | Near-real-time analytics, SaaS/API polling, file drops. |
+| **Streaming** | seconds | Highest — frequent commits, small files | Fraud, monitoring, personalization; seconds matter. |
+
+**Don't buy more freshness than the consumers asked for.** Stage 4 interviews
+routinely reveal that a "real-time" table only needs 5-minute freshness — which
+lets you slow commits from 30 s to minutes and eliminate the small-file problem at
+the source. This is the highest-leverage ingestion fix and it costs nothing.
+
+---
+
+## 3.2 Commit cadence (the small-file root cause)
+
+A streaming writer committing every 30 s makes ~2,880 snapshots/day, each writing
+at least one file per partition it touches. With any partition fan-out, that's the
+classic tiny-file explosion you saw in Stage 2.
+
+**Levers:**
+
+- **Lengthen the commit/checkpoint interval** to the largest value the SLA
+  tolerates. Moving 30 s → 2–5 min cuts file and snapshot count ~4–10×.
+- **Decouple commit interval from processing latency** where the engine allows —
+  process continuously, commit less often.
+- **Accept small files + compact** only when the SLA genuinely needs sub-minute
+  freshness. Then size compaction to keep up (see [maintenance](04-recommendations-maintenance.md)).
+
+Engine specifics:
+
+- **Flink:** commit frequency = **checkpoint interval**
+  (`execution.checkpointing.interval`). This is *the* knob. Also tune the sink's
+  `write-target-file-size-bytes` and consider `write.distribution-mode=hash` so a
+  checkpoint writes one file per partition rather than many.
+- **Spark Structured Streaming:** the **trigger interval** sets micro-batch/commit
+  cadence. `Trigger.ProcessingTime("3 minutes")` over `Trigger.Continuous`/default
+  for Iceberg sinks. `write.distribution-mode=none` for cheapest streaming writes,
+  then compact.
+- **Kafka Connect / Tableflow / Redpanda:** the connector's commit interval and
+  records-per-commit; raise them to batch more per snapshot.
+
+---
+
+## 3.3 Control write distribution & fan-out at the source
+
+Fan-out (one task writing to many partitions) multiplies the small-file problem by
+the partition count. Fix it write-side before relying on compaction:
+
+- Set **`write.distribution-mode=hash`** (or `range` for sorted tables) so the
+  engine shuffles rows to one task per partition — see
+  [§2.4](02-recommendations-table-properties.md#24-write-distribution-mode).
+- For streaming where the shuffle is too expensive, enable
+  **`write.spark.fanout.enabled=true`** (Spark) to avoid per-partition sort
+  buffering, accepting more open files in exchange for not failing/spilling.
+- **Pre-aggregate or repartition** in the job (`.repartition(partitionCols)`)
+  before the write when the engine doesn't do it for you.
+
+---
+
+## 3.4 Match the write operation to the mutation pattern
+
+Iceberg supports `append`, `overwrite` (by filter/partition), row-level
+`update`/`delete`, and `MERGE` (upsert). Choose deliberately:
+
+- **Append-only facts** → plain `append`. Cheapest, fully concurrent across
+  disjoint partitions. The default for event/log/telemetry ingestion.
+- **Partition refresh / reprocessing** → **partition-scoped `overwrite`** (dynamic
+  partition overwrite) so you replace only affected partitions, minimizing write
+  amplification — not a full-table rewrite.
+- **CDC / upserts / SCD** → **`MERGE`** with **MOR** mode (see
+  [§2.5](02-recommendations-table-properties.md#25-copy-on-write-vs-merge-on-read)).
+  Flink and Spark both support MERGE against Iceberg. Position deletes where the
+  engine knows the row; equality deletes where it doesn't (and then compact hard).
+- **GDPR/right-to-erasure deletes** → row-level `delete`, then ensure the multi-step
+  physical-erasure flow in [§4.6](04-recommendations-maintenance.md#46-regulatory-deletion-gd-pr--cc-pa).
+
+---
+
+## 3.5 Concurrency & commit conflicts
+
+Iceberg uses **optimistic concurrency**: each commit does an atomic
+compare-and-swap on the table's metadata pointer; if another writer committed
+first, the loser retries. This scales without locks, but under multiple concurrent
+writers you must plan for conflicts:
+
+- **Partition your writers** so they touch **disjoint partitions** — two appends to
+  different partitions never conflict; two overlapping overwrites do.
+- Raise **`commit.retry.num-retries`** and tune backoff
+  (`commit.retry.min-wait-ms`) for multi-writer tables.
+- Conflicting **overwrites** are the usual culprit — serialize them or scope them
+  tightly. Reserve full-table overwrites for maintenance windows.
+- Failed/retried commits leave **orphan files** behind → ensure orphan cleanup runs
+  (see [§4.4](04-recommendations-maintenance.md#44-orphan-file-removal)).
+
+---
+
+## 3.6 Schema evolution & data quality at ingest
+
+Iceberg evolves schema safely via **stable field IDs** (add/rename/reorder/drop
+without rewriting data). To keep that safety, the *pipeline* must handle drift:
+
+- **Validate incoming schema** against the table each run/continuously (schema
+  registry for streaming: Confluent/Redpanda).
+- Choose a drift strategy per field criticality:
+  - **Fail-fast** on critical fields (reject bad data early).
+  - **Controlled casting** on optional/evolving fields (int→long, string→timestamp).
+  - **Dead-letter queue (DLQ)** for unresolvable rows — keep ingestion flowing,
+    capture rejects for inspection. In practice, combine all three.
+- Don't build a bespoke schema-history store — Iceberg's metadata tables already
+  record schema evolution alongside snapshots (audit trail for free).
+
+---
+
+## 3.7 What each ingestion tool does (and doesn't) do for you
+
+The tool determines how much of the above you own vs inherit. Key Iceberg-relevant
+facts:
+
+| Tool | Model | Iceberg write story | What it automates / caveats |
+|---|---|---|---|
+| **Spark** | batch / micro-batch / structured streaming | Native (Iceberg Spark runtime); append/overwrite/MERGE/streaming. Also the canonical **maintenance** engine. | You own commit cadence (trigger), distribution, and maintenance. Most control, most responsibility. |
+| **Flink** | streaming (+ batch) | Native Iceberg Sink; exactly-once via checkpoint↔commit coordination; CDC/MERGE; position deletes. | Checkpoint interval = commit cadence (the key knob). Watch equality-delete + same-sequence-number upsert pitfalls; compact frequently. |
+| **NiFi** | flow-based micro-batch | `PutIceberg` (1.19.0–1.23.x) writes to **existing** tables via a catalog service. | **Does not create tables or compact** — an external engine (Spark/Trino) must do DDL + maintenance. NiFi 2.0 dropped direct Iceberg; often used to land files for a downstream writer. Batch flowfiles to avoid tiny commits. |
+| **dbt** | batch (warehouse-executed SQL) | Iceberg materializations (`table`/`incremental`/dynamic) on Spark, Snowflake (1.9+), and others. | You set table props/partitioning via model `config`. Incremental models use MERGE — pick `merge`/`append`/`insert_overwrite` strategy. Maintenance is the platform's or a separate job's responsibility. |
+| **Kafka Connect (Iceberg sink)** | streaming | Native sink; commit interval batches records. | Raise commit interval/records-per-commit to avoid tiny files. |
+| **Confluent Tableflow** | streaming | Materializes Kafka topics → Iceberg; auto compaction, schema-registry evolution. | **Append-only** (no upsert/retract); one catalog per cluster; external catalog needs BYO storage. |
+| **Redpanda** | streaming | Topic→Iceberg (spec v2); REST or filesystem catalog; topic-level partitioning; DLQ on schema failure. | Extra CPU for translation; producer backpressure if under-resourced. |
+| **Fivetran / Airbyte / Qlik** | managed ELT (batch/CDC) | Write Parquet→Iceberg via REST catalog; MOR with equality-delete dedup (Airbyte). | Managed services **automate compaction, snapshot/orphan cleanup, stats** (Fivetran, Qlik) — you inherit maintenance. Verify their defaults match your profile. |
+| **Cloud-native (Glue / ADF / Dataflow / Firehose)** | batch + streaming | Glue (Spark) native; ADF Iceberg sink to ADLS; Dataflow lands Parquet for later registration; Firehose → S3/Iceberg. | Maturity varies; check catalog integration and whether the service does any maintenance (mostly it doesn't). |
+
+> See the [platform playbooks](05-platform-playbooks.md) for the full three-category
+> mapping (table / ingestion / maintenance) on Databricks, Snowflake, bespoke,
+> NiFi, Flink, and dbt.
+
+→ Continue to [Maintenance optimization](04-recommendations-maintenance.md).

--- a/research/iceberg-optimization/04-recommendations-maintenance.md
+++ b/research/iceberg-optimization/04-recommendations-maintenance.md
@@ -1,0 +1,208 @@
+# Part II · Chapter 4 — Maintenance optimization
+
+> Ingestion creates entropy; maintenance removes it. Unlike a classic warehouse
+> that tidies itself, an open Iceberg table puts this on you (unless a platform
+> automates it — see [ch. 5](05-platform-playbooks.md)). The four operations are
+> **compaction, snapshot expiration, orphan-file removal, and manifest
+> rewriting.** Drive cadence and scope from the
+> [Stage 2 metadata analysis](01-methodology-and-analysis.md#stage-2--table-metadata-analysis-the-current-physical-layout).
+
+The mantra: **measure from metadata → act with the right procedure → scope it →
+schedule it in read troughs → re-measure.** Maintenance is itself a workload; it
+costs compute and can contend with writers, so scope and timing matter.
+
+---
+
+## 4.1 The four operations at a glance
+
+| Operation | Fixes | Spark procedure | Trigger signal (Stage 2) |
+|---|---|---|---|
+| **Compaction** | small files, poor colocation, MOR delete buildup | `rewrite_data_files` | file p50 small; many `<32 MB`; high delete-file ratio |
+| **Snapshot expiration** | metadata bloat, storage cost, time-travel window | `expire_snapshots` | thousands of snapshots; `metadata.json` growth |
+| **Orphan-file removal** | unreferenced files from failed/retried writes | `remove_orphan_files` | storage > sum of live files; many writer retries |
+| **Manifest rewriting** | manifest fragmentation, slow planning | `rewrite_manifests` | many manifests, few files each; high planning time |
+
+---
+
+## 4.2 Compaction (the highest-impact operation)
+
+**What it does:** rewrites data files to (a) bin-pack small files into target-sized
+ones, (b) optionally **sort/Z-order** to restore colocation, and (c) **apply
+delete files** into clean base files (removing the MOR read tax). It can also
+consolidate manifests in the same pass.
+
+### Strategy
+
+- **`binpack`** (default): just merges to target size. Fast, cheap, fixes the
+  small-file problem. Use when layout (sort) is already fine.
+- **`sort` / `zorder`**: bin-pack *and* reorder by the table's sort keys
+  ([§2.2](02-recommendations-table-properties.md#22-sort-order--clustering)).
+  More expensive; use when Stage 1 shows pruning failures from poor colocation, or
+  to restore order on streaming tables written unsorted.
+
+```sql
+-- bin-pack only, scoped to the hot partition
+CALL system.rewrite_data_files(
+  table => 'db.events',
+  strategy => 'binpack',
+  where => 'event_date = current_date',
+  options => map('target-file-size-bytes','268435456', 'min-input-files','5'));
+
+-- sort/zorder to restore colocation
+CALL system.rewrite_data_files(
+  table => 'db.events', strategy => 'sort',
+  sort_order => 'zorder(tenant_id, country)');
+```
+
+### Key options
+
+| Option | Effect |
+|---|---|
+| `target-file-size-bytes` | output size (mirror the table property). |
+| `min-input-files` | min files in a group before it's worth rewriting (controls granularity/parallelism). |
+| `min-file-size-bytes` / `max-file-size-bytes` | which files are eligible (small ones to merge, oversized ones to split). |
+| `where` | **scope to a partition/filter** — the key to cheap incremental compaction. |
+| `rewrite-job-order` | order file groups (smallest-first to cut file count fast, etc.). |
+| `remove-dangling-deletes` | drop delete files no longer matching live data. |
+| `max-concurrent-file-group-rewrites` | parallelism / resource ceiling. |
+
+### Scoping & cadence
+
+- **Scope with `where`** to hot/recent partitions rather than full-table rewrites —
+  short jobs, bounded cost, no SLA disruption. Drive the filter from Stage 2
+  partition-level file counts.
+- **Cadence by ingestion pattern:**
+  - Streaming / high-churn MOR: **every 1–4 h**, sometimes every few minutes for
+    very high-change CDC, to keep delete files in check.
+  - Micro-batch: a few times a day or after N commits.
+  - Daily batch: **right after each load completes.**
+- **Incremental, narrow-threshold jobs run often** beat occasional full rewrites —
+  they keep the table converged without long, contention-heavy jobs.
+- **MOR health is a sawtooth:** delete-file count should rise (ingest) and fall
+  (compaction) repeatedly. **Monotonic growth = compaction isn't keeping up** →
+  raise frequency or widen scope. For position-delete buildup specifically, use
+  `rewrite_position_delete_files` (v2); v3 deletion vectors largely obviate this.
+
+---
+
+## 4.3 Snapshot expiration
+
+**What it does:** removes old snapshots and the data/metadata files *uniquely*
+referenced by them. Iceberg never deletes a file still needed by a retained
+snapshot, so it's safe — but it does set the time-travel horizon.
+
+**Drive it from:** Stage 4 time-travel/compliance window (a hard requirement that
+*overrides* aggressive expiration) and Stage 2 snapshot count.
+
+```sql
+CALL system.expire_snapshots(
+  table => 'db.events',
+  older_than => TIMESTAMP '2026-06-13 00:00:00',
+  retain_last => 50,
+  max_concurrent_deletes => 8);
+```
+
+**Rules of thumb:**
+
+- **COW tables:** **daily** expiration is usually enough.
+- **MOR / high-frequency CDC:** expire **hourly** (or tighter) — frequent commits
+  bloat history fast, and lingering delete files keep base files alive.
+- **Prefer a time window over a snapshot count** for high-frequency writers: with
+  thousands of commits/day, `retain_last => N` may represent only minutes of
+  history. Use `older_than` to express the real retention intent
+  (e.g. "keep 7 days").
+- Combine with `clean_expired_metadata => true` to drop unreferenced partition
+  specs/schemas; use `stream_results => true` on large tables to spare driver
+  memory.
+- **Branches/tags pin snapshots** and block expiration — audit `<table>.refs` and
+  set `history.expire.max-ref-age-ms` on stale refs.
+- Always pair expiration with **orphan-file removal** (next) to physically reclaim
+  storage.
+
+---
+
+## 4.4 Orphan-file removal
+
+**What it does:** deletes files in the table's storage location that no snapshot
+references — the residue of failed/aborted/retried writes and concurrent-commit
+conflicts. (Distinct from expiration, which removes files that *were* referenced.)
+
+```sql
+CALL system.remove_orphan_files(
+  table => 'db.events',
+  older_than => TIMESTAMP '2026-06-17 00:00:00');   -- ≥3-day safety window
+```
+
+**Rules of thumb:**
+
+- **Always use a safety window (≥3 days, default).** Orphan detection compares the
+  storage listing to live metadata; an in-flight long write looks like an orphan.
+  Too-aggressive cleanup can delete a live write's files. Never run it with a tiny
+  `older_than`.
+- Run **weekly** for most tables; more often for tables with many writer retries
+  (Stage 3) or heavy concurrent writers.
+- Run **after** expiration so newly-unreferenced files are also cleaned.
+
+---
+
+## 4.5 Manifest rewriting
+
+**What it does:** consolidates many small manifests (the signature of frequent
+small commits) into fewer, larger ones aligned to partition boundaries — cutting
+query *planning* time, which is pure overhead paid by every read.
+
+```sql
+CALL system.rewrite_manifests('db.events');
+```
+
+**Rules of thumb:**
+
+- Trigger from Stage 2: many manifests each tracking few files, or high planning
+  latency in query profiles (Stage 1).
+- **Weekly** for high-frequency-commit tables; rarely needed for batch tables.
+- Often folded into the compaction pass.
+
+---
+
+## 4.6 Regulatory deletion (GDPR / CCPA)
+
+Logical delete ≠ physical erasure. Iceberg defers physical removal until snapshots
+expire and files are rewritten/cleaned. To *actually* erase a subject's data, run
+the full chain:
+
+1. **`delete`** the rows (logical).
+2. **Compact** affected partitions so base files are rewritten without the rows —
+   essential for **MOR**, where deletes are only pointers until compaction
+   materializes them.
+3. **Expire every snapshot** that still references the original files (a snapshot
+   anywhere in history keeps them readable).
+4. **Remove orphan files** to purge the now-unreferenced data from storage.
+5. **Beware branches/tags** pinning old snapshots — audit and expire them
+   (`max-ref-age-ms`).
+
+Automate and **log** this chain to demonstrate compliance in an audit; map the
+retention window from Stage 4 onto the expiration schedule.
+
+---
+
+## 4.7 The safe order of operations & scheduling
+
+Run as a pipeline, in this order, in a **read-trough window** (from Stage 1
+time-of-day):
+
+```
+compact ─► expire snapshots ─► remove orphan files ─► rewrite manifests
+   │            │                    │                      │
+ fixes files  trims history     reclaims storage      speeds planning
+```
+
+- Compaction first so expiration/cleanup operate on the consolidated state.
+- Expiration before orphan removal so the just-unreferenced files get swept.
+- **Automate by health, not blanket schedule at scale:** a daily metadata scan
+  (Stage 2 queries) across all tables, computing health metrics, then triggering
+  only the operations a given table needs. This scales to hundreds of tables
+  without per-table babysitting.
+- **Always re-measure** against the Stage 2 baseline (file p50, delete ratio,
+  snapshot count, planning time) — close the loop and tune cadence.
+
+→ Continue to [Platform playbooks](05-platform-playbooks.md).

--- a/research/iceberg-optimization/04-recommendations-maintenance.md
+++ b/research/iceberg-optimization/04-recommendations-maintenance.md
@@ -11,6 +11,16 @@ The mantra: **measure from metadata → act with the right procedure → scope i
 schedule it in read troughs → re-measure.** Maintenance is itself a workload; it
 costs compute and can contend with writers, so scope and timing matter.
 
+> **When *not* to optimize (the cost/scale gate).** Maintenance shifts a recurring
+> *read* cost into a recurring *write/compute* cost — it only pays off when reads
+> are frequent enough to recoup it. Before scheduling work, check the profile:
+> a **cold table** (rarely queried) or a **sub-scale table** (small enough that
+> planning/scan cost is already negligible) may not be worth compacting/clustering
+> at all, and **managed auto-clustering on a high-churn or cold table can cost more
+> than the reads it accelerates.** Optimize where reads are hot; leave cold/tiny
+> tables mostly alone. This gate is the maintenance-side complement to the
+> analysis-first method — derive it from Stage 0 scale + Stage 1 read frequency.
+
 ---
 
 ## 4.1 The four operations at a glance
@@ -64,7 +74,8 @@ CALL system.rewrite_data_files(
 | `where` | **scope to a partition/filter** — the key to cheap incremental compaction. |
 | `rewrite-job-order` | order file groups (smallest-first to cut file count fast, etc.). |
 | `remove-dangling-deletes` | drop delete files no longer matching live data. |
-| `max-concurrent-file-group-rewrites` | parallelism / resource ceiling. |
+| `max-concurrent-file-group-rewrites` | parallelism / resource ceiling (cap it — `rewrite_data_files` is the procedure most prone to OOM). |
+| `partial-progress.enabled` | commit file groups incrementally so a long compaction survives failure or a lost race with a concurrent writer. |
 
 ### Scoping & cadence
 
@@ -78,6 +89,13 @@ CALL system.rewrite_data_files(
   - Daily batch: **right after each load completes.**
 - **Incremental, narrow-threshold jobs run often** beat occasional full rewrites —
   they keep the table converged without long, contention-heavy jobs.
+- **"Compact aggressively" is not free under heavy streaming.** High-frequency
+  streaming commits (especially delete files) can *conflict* with an in-flight
+  compaction's commit, causing retries/churn. Mitigate: scope compaction to
+  partitions the live writer isn't touching, enable `partial-progress`, and raise
+  the writer's `commit.retry.num-retries`. On Flink, ensure expiration/orphan
+  cleanup preserves the job's last snapshot — removing it can cause silent data
+  loss on restart from an older savepoint (apache/iceberg #10892).
 - **MOR health is a sawtooth:** delete-file count should rise (ingest) and fall
   (compaction) repeatedly. **Monotonic growth = compaction isn't keeping up** →
   raise frequency or widen scope. For position-delete buildup specifically, use

--- a/research/iceberg-optimization/05-platform-playbooks.md
+++ b/research/iceberg-optimization/05-platform-playbooks.md
@@ -44,7 +44,7 @@ read/write + lifecycle) and **externally-managed/external-catalog** Iceberg
 |---|---|
 | **Table properties** | On managed tables, set a **`CLUSTERING KEY`** (drives Automatic Clustering) from Stage 1 filters; choose `EXTERNAL_VOLUME` and `BASE_LOCATION`. **v3** (preview early 2026) adds row-level deletes, managed clustering, `variant`. |
 | **Ingestion** | Snowpipe/`COPY`/Snowpipe Streaming, or `INSERT`/`MERGE`. Mine `COPY_HISTORY` for cadence (Stage 3). Streaming ingestion's small files are absorbed by automatic compaction (below). |
-| **Maintenance** | The **Table Optimization Service** bundles **automatic compaction + Automatic Clustering** as a background process for **managed** tables; **manifest compaction** is automatic and can't be disabled. You largely **don't** run manual maintenance on managed tables. |
+| **Maintenance** | The **Table Optimization Service** bundles **automatic compaction + Automatic Clustering** as a background process for **managed** tables; **manifest compaction** is automatic and can't be disabled. You largely **don't** run manual maintenance on managed tables — but Automatic Clustering bills as **continuous serverless credits**, so apply a `CLUSTERING KEY` only to **frequently-queried** tables (on cold/high-churn tables it can cost more than it saves; see the [cost/scale gate](04-recommendations-maintenance.md)). |
 
 **Watch:** for **externally-managed** Iceberg, **Snowflake performs no
 maintenance** — compaction/expiration/cleanup must come from the owning engine

--- a/research/iceberg-optimization/05-platform-playbooks.md
+++ b/research/iceberg-optimization/05-platform-playbooks.md
@@ -1,0 +1,128 @@
+# Part II · Chapter 5 — Platform playbooks
+
+> The same three categories — **table properties / ingestion / maintenance** —
+> but the *division of labor* changes per platform. The big question on every
+> platform is: **what does it automate, and what do you still own?** Managed
+> platforms increasingly run compaction/clustering/expiration for you; bespoke
+> stacks give you every knob and every chore. Match the platform's automation to
+> your [optimization profile](01-methodology-and-analysis.md#stage-5--synthesis-the-optimization-profile)
+> rather than fighting it.
+
+A note on **managed vs externally-managed** tables, which recurs below: when a
+platform *manages* the Iceberg table (it owns the catalog + writes), it can
+maintain it automatically. When it merely *reads* an externally-managed table
+(someone else owns the catalog/writes), it will **not** maintain it — maintenance
+is the writer's job. Know which mode each table is in.
+
+---
+
+## 5.1 Databricks (Unity Catalog)
+
+Databricks now offers **managed Iceberg tables in Unity Catalog** (GA in early
+2026): create/read/write/optimize/govern Iceberg directly, interoperable with
+external engines (Trino, Snowflake, EMR) via UC Open APIs.
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | Prefer **Liquid Clustering** (`CLUSTER BY` keys) over manual partitioning + Z-order — it maintains layout incrementally and is the modern default. Map clustering keys from Stage 1 top filters/join keys. Set spec **v3** for deletion vectors. |
+| **Ingestion** | Spark/Structured Streaming or DLT; control commit cadence via **trigger interval**. CDC via `MERGE` / DLT `APPLY CHANGES` (MOR). Same fan-out/distribution rules as bespoke Spark. |
+| **Maintenance** | **Predictive Optimization** auto-runs `OPTIMIZE` (compaction, incl. clustering), `VACUUM`, and stats — *for UC-managed tables*. On by default for accounts since Nov 2024; rolling out to all by ~2026. You mostly **stop hand-running maintenance** — but verify it's enabled and watch costs. |
+
+**Watch:** Predictive Optimization + Liquid Clustering only apply to **UC-managed**
+tables. Foreign/externally-managed Iceberg tables read via UC are **not**
+auto-maintained. Confirm table type before assuming maintenance is handled.
+
+---
+
+## 5.2 Snowflake
+
+Snowflake supports **Snowflake-managed** Iceberg (Snowflake owns the catalog, full
+read/write + lifecycle) and **externally-managed/external-catalog** Iceberg
+(read-mostly, you maintain it elsewhere).
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | On managed tables, set a **`CLUSTERING KEY`** (drives Automatic Clustering) from Stage 1 filters; choose `EXTERNAL_VOLUME` and `BASE_LOCATION`. **v3** (preview early 2026) adds row-level deletes, managed clustering, `variant`. |
+| **Ingestion** | Snowpipe/`COPY`/Snowpipe Streaming, or `INSERT`/`MERGE`. Mine `COPY_HISTORY` for cadence (Stage 3). Streaming ingestion's small files are absorbed by automatic compaction (below). |
+| **Maintenance** | The **Table Optimization Service** bundles **automatic compaction + Automatic Clustering** as a background process for **managed** tables; **manifest compaction** is automatic and can't be disabled. You largely **don't** run manual maintenance on managed tables. |
+
+**Watch:** for **externally-managed** Iceberg, **Snowflake performs no
+maintenance** — compaction/expiration/cleanup must come from the owning engine
+(Spark/Flink/etc.). Don't assume Snowflake is tidying a table it only reads.
+
+---
+
+## 5.3 Bespoke (Spark / Trino / PyIceberg / Dremio)
+
+The full-control stack: you own every property *and* every maintenance chore. This
+is where Part II ch. 2–4 apply verbatim.
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | Set everything explicitly via `ALTER TABLE … SET TBLPROPERTIES` and `WRITE ORDERED BY` (ch. 2). No automation safety net — get partitioning/sort/file-size right and keep them in version control. |
+| **Ingestion** | Spark (batch/micro-batch/streaming), Trino (`INSERT`/`MERGE` for interactive/ELT), PyIceberg (lightweight Python appends/maintenance, great for small/medium tables and orchestration glue). Apply commit-cadence, distribution, and operation-matching rules from ch. 3. |
+| **Maintenance** | **You run it.** Spark stored procedures (`rewrite_data_files`, `expire_snapshots`, `remove_orphan_files`, `rewrite_manifests`) on a schedule/orchestrator (Airflow). Trino exposes `ALTER TABLE … EXECUTE optimize`; Dremio exposes `OPTIMIZE TABLE` (+ `REWRITE MANIFESTS`) and `VACUUM TABLE` for expiration. Build the **health-driven scheduler** from [§4.7](04-recommendations-maintenance.md#47-the-safe-order-of-operations--scheduling). |
+
+**Engines read large files differently:** Trino/Dremio comfortably scan 1 GB+
+files; memory-limited Spark executors may prefer 128–256 MB. Tune
+`target-file-size-bytes` to the *reading* engine, validated by query plans.
+
+---
+
+## 5.4 Apache NiFi
+
+NiFi is a **pre-ingestion / delivery** layer, not a table manager.
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | **N/A — NiFi cannot create or alter tables.** Define the table (partitioning, sort, props) with Spark/Trino first; NiFi writes into the existing schema. |
+| **Ingestion** | `PutIceberg` (NiFi 1.19.0–1.23.x) writes to an existing table via a catalog service (e.g. `HiveCatalogService`); Record Reader parses input, Parquet/ORC preferred. **Batch flowfiles** (raise merge/record counts) so each commit isn't tiny — NiFi's per-flowfile cadence is a small-file risk. Use `snapshot-property.*` dynamic props to annotate commits for lineage. Use NiFi's backpressure/retry/provenance for observability. NiFi 2.0 **removed** direct Iceberg support — common pattern there: land files to S3 (`PutS3Object`) and let Spark/Flink ingest. |
+| **Maintenance** | **N/A — NiFi does not compact or expire.** A downstream engine (Spark/Trino) must run all of ch. 4. Plan this explicitly; NiFi-fed tables are a classic source of unmanaged small files. |
+
+---
+
+## 5.5 Apache Flink
+
+The streaming writer of choice; naturally suited to MOR/CDC because it knows each
+row's position (→ efficient position deletes / deletion vectors).
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | Set **MOR** modes for CDC/upsert tables; `write.distribution-mode=hash` to cut per-checkpoint fan-out; modest `target-file-size-bytes` (streaming won't fill 512 MB quickly). Define sort order but expect to **restore it via compaction**, not at write time. |
+| **Ingestion** | **Checkpoint interval = commit cadence** (`execution.checkpointing.interval`) — the dominant knob; lengthen to the largest the SLA allows to fight small files. Exactly-once via checkpoint↔Iceberg-commit coordination. CDC/upserts via the Flink sink with equality/position deletes. **Pitfall:** Flink upsert pipelines can commit data files and equality deletes at the *same sequence number*, causing deletes not to apply — validate delete semantics and keep the Iceberg version current. |
+| **Maintenance** | Flink does **not** self-maintain. **Pair Flink (writes) with periodic Spark compaction + expiration** — the standard streaming-lakehouse architecture. MOR demands frequent compaction (every 1–4 h, tighter for high-change) and frequent/hourly snapshot expiration. |
+
+---
+
+## 5.6 dbt
+
+dbt is a **transformation/modeling** layer that emits warehouse-executed SQL; it
+configures table shape but generally **doesn't do maintenance**.
+
+| Category | Guidance |
+|---|---|
+| **Table properties** | Set in the model `config`: `table_format='iceberg'`, `external_volume`/catalog, `partition_by`, and (on Spark) the full range of Iceberg `tblproperties`, transforms, and write modes. `dbt-spark` is the most mature for full Iceberg control; `dbt-snowflake` (1.9+) supports Iceberg `table`/`incremental`/dynamic materializations and `partition_by` for Iceberg tables. |
+| **Ingestion** | Models run as **batch** at warehouse cadence (your scheduler). **Incremental** models use `MERGE` — pick the `incremental_strategy` (`merge` / `append` / `insert_overwrite`) to match the mutation pattern (ch. 3.4). Each run = a snapshot; very frequent dbt runs create snapshot churn. |
+| **Maintenance** | **Not dbt's job.** Either the platform automates it (Databricks Predictive Optimization, Snowflake Table Optimization Service) or you run a **separate maintenance job** (Spark procedures / `OPTIMIZE`). Don't assume `dbt run` compacts anything. A common pattern is a dbt post-hook or a sibling Airflow task that calls the maintenance procedures. |
+
+---
+
+## 5.7 Managed-ELT & streaming connectors (Fivetran, Qlik, Airbyte, Confluent Tableflow, Redpanda)
+
+These **bundle ingestion + (often) maintenance**, trading control for low ops:
+
+- **Fivetran / Qlik:** automate **compaction, snapshot/orphan cleanup, stale-metadata
+  cleanup, and column stats** on the tables they own. You inherit maintenance —
+  but **verify their defaults match your profile** (retention window, file size).
+- **Confluent Tableflow:** Kafka→Iceberg with auto compaction and schema-registry
+  evolution; **append-only** (no upsert/retract), one catalog per cluster.
+- **Redpanda:** topic→Iceberg (spec v2), topic-level partitioning, DLQ on schema
+  failure; you still arrange compaction/expiration for v2 delete buildup.
+- **Airbyte:** Parquet→Iceberg via REST/Glue/Nessie; MOR equality-delete dedup on
+  primary keys; best for periodic/batch syncs. Maintenance generally external.
+
+> Rule: for managed connectors, your job shifts from *doing* maintenance to
+> *auditing* that the managed maintenance matches your Stage 4 requirements
+> (especially retention and time-travel).
+
+→ Continue to [Decision matrices](06-decision-matrices.md).

--- a/research/iceberg-optimization/06-decision-matrices.md
+++ b/research/iceberg-optimization/06-decision-matrices.md
@@ -1,0 +1,99 @@
+# Part II · Chapter 6 — Decision matrices
+
+> The one-page cheat sheet. Use these *after* you've internalized Part I — they
+> compress the workflow into lookups. Each cell still traces back to a profile
+> signal; if a recommendation surprises you, go re-read the relevant analysis
+> stage rather than applying it blindly.
+
+---
+
+## 6.1 Workload archetype → settings
+
+Four common archetypes and the settings that fall out. Find the nearest match to
+your [Stage 0 taxonomy](01-methodology-and-analysis.md#stage-0--frame-the-table-the-workload-taxonomy),
+then adjust from your own profile.
+
+| Setting | **A. Append-only event/log** (full-scan analytics, batch/µbatch, immutable, huge) | **B. CDC dimension** (point-lookup, streaming, mutable, small–med) | **C. BI mart / aggregate** (selective scans, batch, low-mutation, med) | **D. Real-time telemetry** (range scans + dashboards, streaming, append, huge) |
+|---|---|---|---|---|
+| **Partition** | `day(ts)` (`hour` only if huge) | low/none; `bucket(N, key)` | `day`/`month(ts)` + a dim | `hour(ts)` or `day(ts)` |
+| **Sort / cluster** | by 2nd filter (e.g. `tenant`) | by primary key | linear by top filter | by dashboard filter cols |
+| **Target file size** | 256–512 MB | 128–256 MB | 256–512 MB | 128–256 MB |
+| **Distribution mode** | `hash` (`none`+compact if cost-led) | `hash` | `hash`/`range` | `none` + compact |
+| **COW / MOR** | COW (rare deletes) | **MOR** (+ deletion vectors v3) | COW | append → COW |
+| **Commit cadence** | minutes–hourly | seconds–minutes | per batch | seconds (SLA-bound) |
+| **Compaction** | after load / few×day | **1–4 h** (sawtooth) | after load | **1–4 h** |
+| **Snapshot expiry** | daily | **hourly** | daily | hourly |
+
+---
+
+## 6.2 Signal → action (the diagnostic index)
+
+What you observe in analysis → what to change, and where.
+
+| Observed signal (stage) | Likely cause | Action | Chapter |
+|---|---|---|---|
+| `partitions_scanned/total` ≈ 1 (S1) | layout not aligned to predicate | re-partition / add sort key; check pushdown | [2.1](02-recommendations-table-properties.md#21-partitioning)/[2.2](02-recommendations-table-properties.md#22-sort-order--clustering) |
+| file p50 `<32 MB` (S2) | small files | compaction + fix write cadence/distribution | [4.2](04-recommendations-maintenance.md#42-compaction-the-highest-impact-operation) + [3.2](03-recommendations-ingestion.md#32-commit-cadence-the-small-file-root-cause) |
+| high delete-files/scan (S1/S2) | MOR delete buildup | compact more often; `remove-dangling-deletes`; v3 vectors | [4.2](04-recommendations-maintenance.md#42-compaction-the-highest-impact-operation) |
+| thousands of snapshots (S2) | no/loose expiration | expire (time-window for streaming) | [4.3](04-recommendations-maintenance.md#43-snapshot-expiration) |
+| storage ≫ live files (S2) | orphans / unexpired history | orphan removal + expiration | [4.4](04-recommendations-maintenance.md#44-orphan-file-removal) |
+| high planning time (S1) | manifest fragmentation | `rewrite_manifests` | [4.5](04-recommendations-maintenance.md#45-manifest-rewriting) |
+| 13 tiny files/commit @ 30 s (S3) | commit cadence + fan-out | lengthen checkpoint/trigger; `distribution-mode=hash` | [3.2](03-recommendations-ingestion.md#32-commit-cadence-the-small-file-root-cause)/[3.3](03-recommendations-ingestion.md#33-control-write-distribution--fan-out-at-the-source) |
+| many over-partitioned dirs (S2) | granularity too fine | partition evolution → coarser | [2.1](02-recommendations-table-properties.md#21-partitioning) |
+| writer retries / conflicts (S3) | overlapping concurrent writes | disjoint partitions; raise commit retries | [3.5](03-recommendations-ingestion.md#35-concurrency--commit-conflicts) |
+| delete-file count only grows (S2) | compaction not keeping up | raise compaction frequency/scope | [4.2](04-recommendations-maintenance.md#42-compaction-the-highest-impact-operation) |
+
+---
+
+## 6.3 Platform × category: who owns the work
+
+| Platform | Table properties | Ingestion | Maintenance |
+|---|---|---|---|
+| **Databricks (UC-managed)** | `CLUSTER BY` (Liquid Clustering) | Spark/DLT, trigger cadence | **Auto** (Predictive Optimization) ✅ |
+| **Snowflake (managed)** | `CLUSTERING KEY` | Snowpipe/`COPY`/`MERGE` | **Auto** (Table Optimization Service) ✅ |
+| **Snowflake (external)** | read-only | n/a (external writer) | **You** (owning engine) ⚠️ |
+| **Bespoke (Spark/Trino/PyIceberg/Dremio)** | full manual control | full control | **You** (procedures + scheduler) ⚠️ |
+| **NiFi** | ❌ (use Spark first) | `PutIceberg` to existing table | ❌ (downstream engine) ⚠️ |
+| **Flink** | MOR + distribution knobs | checkpoint = commit cadence | ❌ (pair with Spark) ⚠️ |
+| **dbt** | model `config` (props/partition) | batch runs, incremental `MERGE` | ❌ (platform or separate job) ⚠️ |
+| **Managed ELT (Fivetran/Qlik)** | connector-managed | connector-managed | **Auto** (audit defaults) ✅ |
+
+✅ automated · ⚠️ you/another engine must own it · ❌ not supported by this tool
+
+---
+
+## 6.4 Anti-pattern catalog
+
+The recurring mistakes, each a violation of "drive it from evidence":
+
+1. **Partitioning on a high-cardinality column** (`user_id`) → partition
+   explosion. Use `bucket[N]` or sort instead.
+2. **Over-partitioning** (`hour` on a low-volume table) → *causes* small files.
+   Match granularity to partition size, not the calendar.
+3. **Choosing COW to "avoid maintenance"** → write amplification on mutable
+   tables. Choose on workload; manage MOR with compaction.
+4. **Committing every few seconds when the SLA is 5 minutes** → self-inflicted
+   small files. Confirm the real freshness need in interviews.
+5. **Expiring by snapshot count on a streaming table** → `retain_last=N` is
+   minutes of history. Use a time window.
+6. **Aggressive orphan removal with a tiny window** → can delete in-flight
+   writes. Keep ≥3-day safety window.
+7. **Assuming the platform compacts an externally-managed/foreign table** → it
+   doesn't. Know managed vs external; assign the owner.
+8. **Forgotten branches/tags** → silently pin snapshots and block all cleanup.
+   Audit `<table>.refs`; set `max-ref-age-ms`.
+9. **Partitioning/sorting on columns nobody filters** → pure overhead. Verify
+   against query-log frequencies.
+10. **NiFi-fed table with no downstream maintainer** → unmanaged small-file growth.
+    Always assign a Spark/Trino maintenance job.
+
+---
+
+## 6.5 The loop, in one line
+
+> **Profile → set properties → shape ingestion → schedule maintenance →
+> re-profile.** Keep the profile in version control beside the table definition so
+> the *why* travels with the table, and revisit it whenever interviews (Stage 4)
+> say the workload is changing.
+
+← Back to [README / table of contents](README.md).

--- a/research/iceberg-optimization/README.md
+++ b/research/iceberg-optimization/README.md
@@ -53,6 +53,15 @@ properties**, **ingestion**, **maintenance** — and then mapped onto each platf
 - [06 · Decision matrices](06-decision-matrices.md) — workload → settings,
   platform × category cheat sheet, and an anti-pattern catalog.
 
+**Research provenance — the STORM layer**
+
+- [`storm/`](storm/00-method.md) — the research record behind the playbook,
+  produced with the **Stanford STORM method** (multi-perspective scan →
+  contradiction map → synthesis → peer review) run as a five-agent workflow
+  (Practitioner · Skeptic · Economist · Historian · Academic). It stress-tests the
+  playbook's claims from five angles; the peer-review corrections are folded back
+  into the chapters above. Start at [`storm/00-method.md`](storm/00-method.md).
+
 ## Scope & honesty notes
 
 - This is a **methodology framework**, not a report on a specific dataset. Where

--- a/research/iceberg-optimization/README.md
+++ b/research/iceberg-optimization/README.md
@@ -1,0 +1,67 @@
+# The Iceberg Optimization Playbook
+
+A research "book" on optimizing Apache Iceberg tables across engines and platforms.
+
+It is organized the way the work actually happens: **analyze first, then
+recommend.** You don't pick a target file size or a clustering key in a vacuum —
+you derive it from how the table is *written* and *read*. So Part I is a
+methodology for turning four evidence streams (query logs, table metadata,
+ingestion logs, user interviews) into a per-table **optimization profile**, and
+Part II turns that profile into concrete settings, split three ways — **table
+properties**, **ingestion**, **maintenance** — and then mapped onto each platform
+(Databricks, Snowflake, bespoke Spark/Trino/PyIceberg, NiFi, Flink, dbt).
+
+## How to use this book
+
+1. Read **Part I** once to internalize the workflow. It is engine-agnostic.
+2. For a given table, run the analysis in [`01-methodology-and-analysis.md`](01-methodology-and-analysis.md)
+   and fill in an **optimization profile** (the template at the end of that file).
+3. Pull the matching recommendations from the three category chapters
+   ([table properties](02-recommendations-table-properties.md),
+   [ingestion](03-recommendations-ingestion.md),
+   [maintenance](04-recommendations-maintenance.md)).
+4. Translate them to your platform with the
+   [platform playbooks](05-platform-playbooks.md).
+5. Use the [decision matrices](06-decision-matrices.md) as the one-page cheat
+   sheet once you know the workflow.
+
+## Table of contents
+
+**Part I — Analysis (the workflow)**
+
+- [01 · Methodology & analysis](01-methodology-and-analysis.md) — the four
+  evidence streams, what to query, what each signal implies, and the synthesis
+  step that produces an optimization profile.
+
+**Part II — Recommendations**
+
+- [02 · Table-properties optimization](02-recommendations-table-properties.md) —
+  partitioning, sort/clustering, file size, write distribution, COW vs MOR,
+  compression, metadata hygiene knobs.
+- [03 · Ingestion optimization](03-recommendations-ingestion.md) — batch vs
+  streaming, commit cadence, the small-file problem at the source, upserts/CDC,
+  fanout, write-side distribution.
+- [04 · Maintenance optimization](04-recommendations-maintenance.md) —
+  compaction, snapshot expiration, orphan-file removal, manifest rewriting,
+  scheduling and the safe order of operations.
+
+**Part II (continued) — by platform**
+
+- [05 · Platform playbooks](05-platform-playbooks.md) — Databricks, Snowflake,
+  bespoke (Spark/Trino/PyIceberg), NiFi, Flink, dbt; each mapped to the three
+  categories above, including what the platform automates for you.
+- [06 · Decision matrices](06-decision-matrices.md) — workload → settings,
+  platform × category cheat sheet, and an anti-pattern catalog.
+
+## Scope & honesty notes
+
+- This is a **methodology framework**, not a report on a specific dataset. Where
+  it shows SQL, the queries are real and runnable against Iceberg metadata tables
+  or a query-history store; there are **no fabricated result numbers**.
+- Numeric recommendations (e.g. "target 128–512 MB files") are the documented
+  community/vendor defaults and rules of thumb current as of mid-2026, with
+  sources listed in [`SOURCES.md`](SOURCES.md). Treat them as starting points to
+  validate against your own profile, not laws.
+- Iceberg moves fast. Spec **v3** (row lineage, deletion vectors, the `variant`
+  and `geo` types) reached GA/preview across the major platforms in early 2026;
+  where a recommendation depends on the format version, this is called out.

--- a/research/iceberg-optimization/SOURCES.md
+++ b/research/iceberg-optimization/SOURCES.md
@@ -5,6 +5,23 @@ documentation, vendor/platform docs, practitioner writing, and one long-form
 source supplied for this research. Numeric rules of thumb are community/vendor
 defaults current as of mid-2026; validate against your own optimization profile.
 
+## STORM research layer
+
+The full, per-perspective source lists (Practitioner, Skeptic, Economist,
+Historian, Academic — ~60 distinct URLs incl. SIGMOD/VLDB/CIDR papers, the Iceberg
+spec, vendor docs, GitHub issues, and critical/contrarian writing) live in
+[`storm/01-perspectives.md`](storm/01-perspectives.md).
+
+**Verification caveat (important):** the research environment blocked direct fetch
+(HTTP 403) of many primary pages, so some **specific figures** were drawn from
+search-result snippets, not full-page reads. Do **not** republish these as hard
+facts without re-checking the source: Amazon S3 Tables "up to 90%"; serverless DBU
+rates; GET "$0.0004/1k"; the "$4,500–7,000/mo" example; the "$1–2B" Tabular price;
+Snowflake "99.4% pruned". Procedure defaults (512 MB target, 3-day orphan window,
+`min-input-files=5`, etc.) are corroborated across sources and match the Apache
+docs but are worth a final docs check. See
+[`storm/04-peer-review.md`](storm/04-peer-review.md).
+
 ## Supplied source
 
 - *Architecting an Apache Iceberg Lakehouse* (manuscript, dated 2026-06-18) —

--- a/research/iceberg-optimization/SOURCES.md
+++ b/research/iceberg-optimization/SOURCES.md
@@ -1,0 +1,64 @@
+# Sources
+
+The recommendations in this book are synthesized from the Apache Iceberg
+documentation, vendor/platform docs, practitioner writing, and one long-form
+source supplied for this research. Numeric rules of thumb are community/vendor
+defaults current as of mid-2026; validate against your own optimization profile.
+
+## Supplied source
+
+- *Architecting an Apache Iceberg Lakehouse* (manuscript, dated 2026-06-18) —
+  esp. ch. 5 (ingestion layer), ch. 9 (maintenance: small files, colocation,
+  metadata sprawl, MOR, compaction, snapshot expiration, COW vs MOR retention,
+  GDPR), and the metadata-tables appendix. Used for compaction options, COW/MOR
+  retention guidance, expiration cadence (daily COW / hourly MOR), dangling
+  deletes, branch/tag retention, and the ingestion-tool survey.
+
+## Apache Iceberg internals & procedures
+
+- Apache Iceberg docs — Spark procedures (`rewrite_data_files`,
+  `expire_snapshots`, `remove_orphan_files`, `rewrite_manifests`,
+  `rewrite_position_delete_files`): https://iceberg.apache.org/docs/latest/spark-procedures/
+- Dremio — *Compaction in Apache Iceberg* / *Maintaining Iceberg Tables*:
+  https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/
+  · https://www.dremio.com/blog/maintaining-iceberg-tables-compaction-expiring-snapshots-and-more/
+- Dremio — *Row-Level Changes: Copy-On-Write vs Merge-On-Read*:
+  https://www.dremio.com/blog/row-level-changes-on-the-lakehouse-copy-on-write-vs-merge-on-read-in-apache-iceberg/
+- AWS Prescriptive Guidance — *Optimizing write performance* (distribution mode,
+  target file size): https://docs.aws.amazon.com/prescriptive-guidance/latest/apache-iceberg-on-aws/best-practices-write.html
+- Cloudera — *Optimization Strategies for Iceberg Tables*:
+  https://www.cloudera.com/blog/technical/optimization-strategies-for-iceberg-tables.html
+- IOMETE — *The Iceberg Maintenance Runbook*:
+  https://iomete.com/resources/blog/iceberg-maintenance-runbook
+- Alex Merced — Iceberg metadata tables / maintenance masterclass:
+  https://iceberglakehouse.com/posts/2026-04-29-iceberg-masterclass-10/
+
+## Platform docs
+
+- Databricks — *Predictive optimization for Unity Catalog managed tables*:
+  https://docs.databricks.com/aws/en/optimizations/predictive-optimization
+- Databricks — *Liquid clustering*:
+  https://docs.databricks.com/aws/en/tables/clustering
+- Databricks — *Unity Catalog and the next era of Apache Iceberg* (managed
+  Iceberg GA, v3): https://www.databricks.com/blog/unity-catalog-and-next-era-apache-icebergtm
+- Snowflake — *Manage Apache Iceberg tables* (managed vs external, automatic
+  maintenance): https://docs.snowflake.com/en/user-guide/tables-iceberg-manage
+- Snowflake — Iceberg tables architecture & 2026 features (Table Optimization
+  Service, v3 preview): https://www.flexera.com/blog/finops/snowflake-iceberg-table/
+- dbt — *Snowflake and Apache Iceberg* / Snowflake configs:
+  https://docs.getdbt.com/docs/mesh/iceberg/snowflake-iceberg-support
+  · https://docs.getdbt.com/reference/resource-configs/snowflake-configs
+- dbt — Spark configs (Iceberg): https://docs.getdbt.com/reference/resource-configs/spark-configs
+- Apache NiFi — `PutIceberg` processor:
+  https://docs.cloudera.com/cfm/4.10.0/nifi-components-cfm/docs/nifi-docs/components/org.apache.nifi/nifi-iceberg-processors-nar/x/org.apache.nifi.processors.iceberg.PutIceberg/index.html
+- Apache Iceberg — Flink writes / sink (checkpoint↔commit, deletes):
+  https://iceberg.apache.org/docs/latest/flink-writes/
+  · upsert/equality-delete pitfall: https://github.com/apache/iceberg/issues/15305
+
+## Small-file & streaming references
+
+- Dremio — *Minimizing Iceberg Table Management with Smart Writing*:
+  https://www.dremio.com/blog/minimizing-iceberg-table-management-with-smart-writing/
+- Ancestry Eng. — *Solving the Small File Problem in Iceberg Tables*:
+  https://medium.com/ancestry-product-and-technology/solving-the-small-file-problem-in-iceberg-tables-6c31a295f724
+- OLake — *Merge-on-Read vs Copy-on-Write*: https://olake.io/iceberg/mor-vs-cow/

--- a/research/iceberg-optimization/SOURCES.md
+++ b/research/iceberg-optimization/SOURCES.md
@@ -12,14 +12,36 @@ Historian, Academic — ~60 distinct URLs incl. SIGMOD/VLDB/CIDR papers, the Ice
 spec, vendor docs, GitHub issues, and critical/contrarian writing) live in
 [`storm/01-perspectives.md`](storm/01-perspectives.md).
 
-**Verification caveat (important):** the research environment blocked direct fetch
-(HTTP 403) of many primary pages, so some **specific figures** were drawn from
-search-result snippets, not full-page reads. Do **not** republish these as hard
-facts without re-checking the source: Amazon S3 Tables "up to 90%"; serverless DBU
-rates; GET "$0.0004/1k"; the "$4,500–7,000/mo" example; the "$1–2B" Tabular price;
-Snowflake "99.4% pruned". Procedure defaults (512 MB target, 3-day orphan window,
-`min-input-files=5`, etc.) are corroborated across sources and match the Apache
-docs but are worth a final docs check. See
+**Verification caveat (important).** This session's environment can only reach an
+**allowlisted set of domains** through its egress proxy — GitHub resolves (HTTP
+200), but essentially everything else (arXiv, AWS, Snowflake/Databricks docs,
+VLDB, RisingWave, Hacker News — and `api.firecrawl.dev` itself) returns **HTTP
+403**. So full-text reads of non-GitHub sources weren't possible; those claims rest
+on `WebSearch` snippets. (Firecrawl can't work around this: there's no Firecrawl
+tool or key here, and its API endpoint is itself blocked by the allowlist. A true
+full-sourcing replay would need the **network policy broadened** for this session —
+see https://code.claude.com/docs/en/claude-code-on-the-web — or the sources fetched
+from a less restricted environment.)
+
+**Verified by direct read (GitHub, allowlisted):**
+- [#8729](https://github.com/apache/iceberg/issues/8729) — `write.target-file-size-bytes`
+  set to 512 MB but output files were ~100 MB. ✅ (drives the §2.3 "verify output,
+  the knob isn't always honored" caveat)
+- [#10892](https://github.com/apache/iceberg/issues/10892) — restoring a Flink job
+  from an older savepoint can silently skip Iceberg commits while Kafka offsets
+  advance → silent data loss. ✅ (drives the §4.2 Flink warning)
+- [#13674](https://github.com/apache/iceberg/issues/13674) — `rewrite_data_files`
+  OOM during equality-delete filtering; mitigated with `partial-progress.enabled`
+  and `max-concurrent-file-group-rewrites=1`. ✅ (drives the §4.2 options rows)
+- [trinodb/trino #26563](https://github.com/trinodb/trino/issues/26563) — Iceberg
+  planning 7 ms → ~3 min with statistics on; 5–10% of queries 1–10 min on
+  2,000+-partition tables. ✅
+
+**Still snippet-only — do NOT republish as hard facts without re-checking:** Amazon
+S3 Tables "up to 90%"; serverless DBU rates; GET "$0.0004/1k"; the "$4,500–7,000/mo"
+example; the "$1–2B" Tabular price; Snowflake "99.4% pruned". Procedure defaults
+(512 MB target, 3-day orphan window, `min-input-files=5`, etc.) are corroborated
+across sources and match the Apache docs but warrant a final docs check. See
 [`storm/04-peer-review.md`](storm/04-peer-review.md).
 
 ## Supplied source

--- a/research/iceberg-optimization/storm/00-method.md
+++ b/research/iceberg-optimization/storm/00-method.md
@@ -1,0 +1,65 @@
+# STORM research layer
+
+This directory documents the research behind the Iceberg Optimization Playbook,
+conducted with the **Stanford STORM method** — *Synthesis of Topic Outlines
+through Retrieval and Multi-perspective Question asking* (Stanford OVAL Lab,
+NAACL 2024) — in the practical four-phase form, with **source retrieval added at
+every phase** (the higher-reliability variant).
+
+The point of STORM: a single research prompt returns the *majority framing* of a
+topic. Asking from multiple expert perspectives first, then mapping where they
+disagree, surfaces blind spots and separates consensus from genuine debate before
+anything is written.
+
+## How it was run here (an agents workflow)
+
+```
+        ┌─────────────────────────────────────────────────────────────┐
+ Phase 1│  MULTI-PERSPECTIVE SCAN  (5 parallel research agents)         │
+        │  Practitioner · Skeptic · Economist · Historian · Academic   │
+        │  each: research with web retrieval → claims + 4-5 sources     │
+        └───────────────────────────────┬─────────────────────────────┘
+                                        ▼
+ Phase 2│  CONTRADICTION MAP   where the perspectives disagree, why,    │
+        │  and which claims are well-supported / weak / missing         │
+                                        ▼
+ Phase 3│  SYNTHESIS BRIEFING  findings · tradeoffs · reliability       │
+        │  ranking · recommended actions                                │
+                                        ▼
+ Phase 4│  PEER REVIEW   critique the briefing: strong/weak claims,     │
+        │  biases, missing angles, what needs source verification       │
+        └─────────────────────────────────────────────────────────────┘
+```
+
+- **Phase 1** was executed as a literal **agents workflow**: five independent
+  research subagents, one per perspective, run in parallel. Each was instructed to
+  do real web retrieval and attach 4–5 credible sources to its claims (per the
+  STORM caveat that persona-prompting without retrieval is just structured
+  guessing).
+- **Phases 2–4** are the orchestrator's synthesis over the five scans.
+
+## Files
+
+| File | Phase | Contents |
+|---|---|---|
+| [`01-perspectives.md`](01-perspectives.md) | 1 | The five sourced perspective scans, verbatim. |
+| [`02-contradiction-map.md`](02-contradiction-map.md) | 2 | Where perspectives disagree; evidence strength. |
+| [`03-synthesis-briefing.md`](03-synthesis-briefing.md) | 3 | The research briefing with reliability ranking. |
+| [`04-peer-review.md`](04-peer-review.md) | 4 | Self-critique of the briefing. |
+
+## Relationship to the main book
+
+The main [Iceberg Optimization Playbook](../README.md) (the analysis-first
+methodology + category/platform recommendations) is the *product*. This STORM
+layer is the *research record* behind it: it stress-tests the playbook's claims
+from five angles and records where the advice is solid, contested, or
+context-dependent. Where the peer review (Phase 4) flagged a material correction,
+it was folded back into the main chapters — those edits are noted in
+[`04-peer-review.md`](04-peer-review.md).
+
+## Honesty note
+
+Perspective personas are a thinking tool, not authorities. Every substantive claim
+is tied to a retrieved source; claims without a source are labelled as reasoning,
+not fact. The reliability ranking in the synthesis reflects how well each finding
+is actually supported, not how confidently any single perspective stated it.

--- a/research/iceberg-optimization/storm/01-perspectives.md
+++ b/research/iceberg-optimization/storm/01-perspectives.md
@@ -1,0 +1,243 @@
+# Phase 1 — Multi-perspective scan
+
+Five independent research agents scanned **Apache Iceberg optimization** through
+distinct expert lenses, each with web retrieval and sources attached. Their
+scans are reproduced verbatim below. The orchestrator's cross-perspective work
+(contradictions, synthesis, peer review) follows in the next files.
+
+> **A shared sourcing caveat.** Every agent reported that many authoritative
+> sites (apache.org, vendor docs, arXiv/ACM/VLDB PDFs, HN item pages) returned
+> **HTTP 403** to the page fetcher in this environment, so a number of specific
+> figures come from search-result snippets rather than full-page reads. All URLs
+> are real and were surfaced by search; **specific numbers (DBU rates, "99.4%
+> pruned", "up to 90%", the $1–2B Tabular price, etc.) should be re-verified
+> against the live source before being quoted as hard facts.** This is itself a
+> Phase-4 peer-review finding.
+
+---
+
+## Practitioner perspective
+
+### What this perspective notices
+
+**Cross-cutting reality:** Iceberg's table format is excellent, but a freshly-created table is *not* a self-maintaining table. The format gives you snapshots, manifests, and ACID commits; it does *not* give you compaction, snapshot expiry, or orphan cleanup for free unless you're on a managed engine. The single biggest day-2 surprise for newcomers is that "small files" and "metadata bloat" are operational problems you own, not bugs.
+
+**Table-properties:**
+- Defaults are not production defaults. `write.distribution-mode` defaults to `none` (no shuffle) — fine for a single big partition, catastrophic for a high-cardinality partitioned table because every Spark task writes one small file per partition it touches. Practitioners flip this to `hash` early.
+- `write.target-file-size-bytes` is a *target/ceiling*, not a guarantee. A single Spark task that produces less data than the target still emits a small file; a task with more produces multiple files. The property doesn't fix skew or fan-out.
+- Format v2 vs v1, and copy-on-write vs merge-on-read, is the choice that quietly determines your entire maintenance burden. MoR makes writes cheap and reads expensive, and *requires* delete-file compaction to stay healthy.
+
+**Ingestion:**
+- The fundamental tension in every streaming sink (Flink, Kafka Connect, Spark Structured Streaming): commit frequency drives correctness/latency, and frequent commits *manufacture* small files. There is no streaming config that avoids this — you pair it with aggressive downstream compaction.
+- Checkpoint interval is the real "files per minute" knob in Flink, more than any Iceberg property.
+- MERGE-heavy ingestion (CDC, dbt incremental) is where reads silently rot: each merge writes delete files / rewrites, and without compaction your read amplification climbs.
+
+**Maintenance:**
+- Order matters and is non-obvious: expire snapshots → remove orphan files → rewrite manifests/data. Running manifest rewrite while old snapshots are retained only optimizes what the current snapshot references — wasted work.
+- The scary procedure is `remove_orphan_files`: its 3-day default exists specifically so it doesn't delete files an in-flight write is still committing. Shortening it without understanding your longest job duration is a known way to corrupt a table.
+- `rewrite_data_files` is the procedure most likely to OOM, run for hours, or fail with concurrent-write conflicts on a busy table — it's not "fire and forget."
+
+### Key claims (each with a source)
+
+1. **`write.target-file-size-bytes` defaults to 536870912 (512 MB), and it's a target/max, not a minimum** — a single Spark task under that size still produces a small file, and tasks over it split into multiple files. ([Apache Iceberg — Spark Writes](https://iceberg.apache.org/docs/latest/spark-writes/))
+2. **`write.distribution-mode` defaults to `none` (no shuffle); switch to `hash` for evenly-partitioned tables to stop per-task-per-partition small-file explosions** — `none` is only appropriate when rows land in few partitions. ([Iceberg docs — distribution mode clarification](https://www.mail-archive.com/commits@iceberg.apache.org/msg10610.html))
+3. **Practical target file size is 128 MB–512 MB; below ~128 MB you pay metadata/planning overhead, above ~1 GB you lose pruning effectiveness.** ([Dremio — Compaction in Apache Iceberg](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/))
+4. **`rewrite_data_files` key options/defaults: `min-input-files`=5, `max-concurrent-file-group-rewrites`=5, `partial-progress.enabled`=false.** Partial-progress lets it commit file groups incrementally so a long compaction survives failure/races. ([Apache Iceberg — Spark Procedures](https://iceberg.apache.org/docs/latest/spark-procedures/))
+5. **`rewrite_data_files` is the procedure most prone to OOM and concurrent-write conflicts** — cap `max-concurrent-file-group-rewrites`, compact per-partition, enable partial progress. ([apache/iceberg #13674](https://github.com/apache/iceberg/issues/13674), [#9521](https://github.com/apache/iceberg/issues/9521))
+6. **`remove_orphan_files` defaults to a 3-day retention as a safety guard against deleting in-flight-write files; shortening it below your longest job can corrupt the table.** ([Apache Iceberg — Maintenance](https://iceberg.apache.org/docs/latest/maintenance/))
+7. **Safe maintenance order is expire snapshots → remove orphan files → rewrite manifests.** ([IOMETE — Maintenance Runbook](https://iomete.com/resources/blog/iceberg-maintenance-runbook))
+8. **MoR tables require mandatory regular compaction; position deletes are tied to data-file positions and become invalid when the base file is compacted, so they must be rewritten too.** ([OLake — MoR vs CoW](https://olake.io/iceberg/mor-vs-cow/))
+9. **Streaming sinks create small files because they commit at every checkpoint** (a 30 s interval = a commit every 30 s); pair with aggressive compaction; `write.distribution-mode=hash` in the Flink sink reduces source-side small files. ([Apache Iceberg — Flink Writes](https://iceberg.apache.org/docs/latest/flink-writes/), [Streaming into Iceberg](https://iceberglakehouse.com/posts/2026-04-29-iceberg-masterclass-13/))
+10. **dbt transforms but does not maintain Iceberg tables** — passes properties via `table_properties`, but compaction/expiry/orphan-cleanup run separately; use `incremental_predicates` to bound the MERGE scan. ([LakeOps — dbt Iceberg](https://lakeops.dev/blog/dbt-iceberg-optimization), [dbt — Athena configs](https://docs.getdbt.com/reference/resource-configs/athena-configs))
+11. **Managed ingestion automates small files differently per vendor:** Confluent Tableflow auto-compacts and expires; Fivetran consolidates inline and expires snapshots daily on a configurable retention. ([Confluent — Tableflow GA](https://www.confluent.io/blog/tableflow-ga-kafka-snowflake-iceberg/), [Fivetran — Iceberg](https://www.fivetran.com/blog/get-started-with-iceberg-without-the-brain-freeze))
+12. **Managed-engine maintenance is opaque and scoped to the managing engine:** Snowflake managed Iceberg auto-runs compaction/manifest-opt/snapshot-expiry (some non-disableable) but only for Snowflake-managed tables; Databricks Predictive Optimization auto-runs OPTIMIZE/VACUUM/ANALYZE on UC-managed tables. ([Snowflake — Managed Iceberg](https://www.snowflake.com/en/blog/engineering/managed-iceberg-tables/), [IOMETE — Maintenance Landscape](https://iomete.com/resources/blog/iceberg-maintenance-alternatives))
+
+### Where this perspective is limited / blind spots
+- Over-indexes on small files/compaction (the thing that pages you); under-weights schema/partition *design*, which often matters more.
+- Published numbers ("256–512 MB", "min-input-files=5", "compact daily") are starting points, not universal truths — they get cargo-culted.
+- Reaches for procedures over root cause (scheduling compaction instead of fixing checkpoint interval / distribution mode).
+- Managed-platform behavior is largely unverifiable from outside (when it runs, how aggressive, what it costs).
+- Under-weights cost and multi-engine governance; biased toward Spark/Trino tooling where the mature procedures live.
+
+### Sources
+- [Apache Iceberg — Maintenance](https://iceberg.apache.org/docs/latest/maintenance/) · [Spark Procedures](https://iceberg.apache.org/docs/latest/spark-procedures/) · [Spark Writes](https://iceberg.apache.org/docs/latest/spark-writes/) · [Flink Writes](https://iceberg.apache.org/docs/latest/flink-writes/)
+- [Iceberg commits list — distribution mode defaults](https://www.mail-archive.com/commits@iceberg.apache.org/msg10610.html)
+- [apache/iceberg #13674 — rewrite_data_files OOM](https://github.com/apache/iceberg/issues/13674) · [#9521 — concurrent write conflict](https://github.com/apache/iceberg/issues/9521)
+- [Dremio — Compaction in Apache Iceberg](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/)
+- [IOMETE — Maintenance Runbook](https://iomete.com/resources/blog/iceberg-maintenance-runbook) · [Maintenance Landscape](https://iomete.com/resources/blog/iceberg-maintenance-alternatives)
+- [OLake — MoR vs CoW](https://olake.io/iceberg/mor-vs-cow/) · [Iceberg Lakehouse — Streaming into Iceberg](https://iceberglakehouse.com/posts/2026-04-29-iceberg-masterclass-13/)
+- [LakeOps — dbt Iceberg Optimization](https://lakeops.dev/blog/dbt-iceberg-optimization) · [dbt — Athena configs](https://docs.getdbt.com/reference/resource-configs/athena-configs)
+- [Confluent — Tableflow GA](https://www.confluent.io/blog/tableflow-ga-kafka-snowflake-iceberg/) · [Fivetran — Iceberg](https://www.fivetran.com/blog/get-started-with-iceberg-without-the-brain-freeze) · [Snowflake — Managed Iceberg Tables](https://www.snowflake.com/en/blog/engineering/managed-iceberg-tables/)
+
+---
+
+## Skeptic perspective
+
+### What this perspective notices
+
+**Table-properties**
+- The canonical "target 128–512 MB files" advice is treated as a universal law, but `write.target-file-size-bytes` is **not reliably honored** by writers — people set 512 MB and get ~100 MB files, then cargo-cult the setting without verifying output. The "right" size is workload- and engine-dependent.
+- Defaults are quietly contested and keep changing (e.g. default `write.distribution-mode` moving from `none` toward `hash`/`range`), so "best practice" copied from a 2022 blog can be actively wrong now — and `hash`/`range` trades small-file reduction for shuffle cost nobody benchmarks.
+- Bloom filters, column metrics, and clustering are sold as free wins but carry write-time and metadata-size costs; "enable everything to be safe" is an anti-pattern.
+
+**Ingestion**
+- Iceberg was built at Netflix for petabyte-scale, slow-moving tables. Most shops run gigabytes, where the metadata indirection and mandatory maintenance are pure overhead — "your biggest table fits on a laptop" yet you run Spark OPTIMIZE on it.
+- Streaming/CDC is where the format is weakest: frequent commits create small-file/metadata explosions; **MoR with equality deletes pushes unbounded cost onto every reader**; "real-time Iceberg" is gated on the writer finishing a Parquet upload and swapping the pointer.
+- Non-JVM clients (PyIceberg, Rust, Go, C++) lag the Java reference and often lack compaction/maintenance, so "engine-agnostic" is aspirational; ClickHouse/DuckDB are read-only or write-experimental.
+
+**Maintenance**
+- "Just turn on auto-optimization" hides a serverless meter that bills whether or not anyone queries the table; managed compaction/clustering can cost more than the queries it accelerates.
+- Maintenance is **destructive and order-sensitive**: snapshot expiration + orphan-file deletion can corrupt active Flink jobs and cause silent data loss if run wrong.
+- The "set it and forget it lakehouse" pitch is false — without continuous compaction, manifest rewrites, and snapshot expiry, tables degrade; maintenance is a permanent tax.
+
+### Key claims (each with a source)
+1. **The target-file-size knob is not always respected** — users set 512 MB and still get ~100 MB files. ([apache/iceberg #8729](https://github.com/apache/iceberg/issues/8729))
+2. **Optimal file size is contested, not canonical** — 128 vs 256 vs 512 MB all recommended for "most workloads." ([Dremio — Compaction](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/))
+3. **MoR + equality deletes shifts unbounded cost onto readers** and is "almost the only choice" for streaming CDC — a structural, not incidental, problem. ([RisingWave — The Equality Delete Problem](https://risingwave.com/blog/the-equality-delete-problem-in-apache-iceberg/); [HN](https://news.ycombinator.com/item?id=44880081))
+4. **"Iceberg is the new Hadoop" — overhyped and mismatched to most orgs' scale**, reintroducing small-file pain and demanding continuous tuning. ([Data Engineering Weekly](https://www.dataengineeringweekly.com/p/is-apache-iceberg-the-new-hadoop); [HN](https://news.ycombinator.com/item?id=43277214))
+5. **Petabyte-scale design is friction at gigabyte scale** — extra indirection "worthwhile at petabyte scale but questionable at gigabyte scale." ([Quesma — Practical Limitations 2025](https://quesma.com/blog/apache-iceberg-practical-limitations-2025/))
+6. **"Engine-agnostic" is overstated** — non-JVM clients lag and lack maintenance tooling; some engines are read-only. ([Quesma — Practical Limitations 2025](https://quesma.com/blog/apache-iceberg-practical-limitations-2025/))
+7. **Managed auto-optimization can cost more than it saves** — Snowflake auto-clustering "racks up credits whether anyone's using the table or not." ([DataEngineer Hub — Snowflake Managed Iceberg](https://dataengineerhub.blog/articles/snowflake-managed-iceberg-tables-complete-guide-2026))
+8. **Maintenance is destructive — can cause silent data loss in streaming** — expiring snapshots/removing orphans is coupled to active Flink writers; restoring from an old savepoint after cleanup "might trigger silent data loss." ([apache/iceberg #10892](https://github.com/apache/iceberg/issues/10892); [Conduktor](https://www.conduktor.io/glossary/maintaining-iceberg-tables-compaction-and-cleanup))
+9. **Streaming writes structurally conflict with compaction** — high-frequency delete-file commits are "very likely to conflict with any ongoing compaction." ([Iceberg dev list — streaming upserts](https://www.mail-archive.com/dev@iceberg.apache.org/msg12513.html))
+10. **Query *planning* itself can be the bottleneck** — on Trino with stats on, 5–10% of queries spent 1–10 min in planning; meta-table queries "too slow for practical use." ([trinodb/trino #26563](https://github.com/trinodb/trino/issues/26563))
+11. **Unmaintained tables silently degrade** — metadata can grow larger than the data, requiring a full rewrite to recover. ([IOMETE — Maintenance Runbook](https://iomete.com/resources/blog/iceberg-maintenance-runbook))
+12. **Partition evolution complicates compaction** — mixed specs yield inconsistent layouts and degraded pushdown; some engines fail to rewrite across spec conflicts. ([Alex Merced — Hidden Pitfalls](https://dev.to/alexmercedcoder/apache-iceberg-table-optimization-8-hidden-pitfalls-compaction-and-partition-evolution-in-13f1))
+13. **Catalog choice is the real lock-in, not the file format** — "creating a table within a specific catalog locks you in… the catalog vendor [has] significant strategic power." ([Confluent/Medium — Table Format War](https://medium.com/confluent/will-apache-iceberg-win-the-table-format-war-01f6ff0d556d))
+
+### Where this perspective is limited / blind spots
+- Underweights genuine improvements (hidden partitioning, evolution, snapshot isolation); many cited pains are being actively fixed, so the critique ages fast.
+- Over-indexes on small-scale orgs; the cost/benefit flips with scale, concurrency, and number of engines.
+- Conflates operational immaturity (missing runbooks) with format defects.
+- Survivorship/negativity bias: GitHub/HN over-represent breakage; "skeptic" vendors still sell competing products.
+- Treats complexity as disqualifying when, for the right workload, it's essential.
+
+### Sources
+- [Data Engineering Weekly — Is Iceberg the New Hadoop?](https://www.dataengineeringweekly.com/p/is-apache-iceberg-the-new-hadoop) · [Quesma — Practical Limitations 2025](https://quesma.com/blog/apache-iceberg-practical-limitations-2025/) · [HN: Practical Limitations](https://news.ycombinator.com/item?id=44063370) · [HN: Hadoop of the modern stack?](https://news.ycombinator.com/item?id=43277214)
+- [RisingWave — Equality Delete Problem](https://risingwave.com/blog/the-equality-delete-problem-in-apache-iceberg/) · [HN: equality delete](https://news.ycombinator.com/item?id=44880081) · [apache/iceberg #13000 — MoR indexing](https://github.com/apache/iceberg/issues/13000)
+- [apache/iceberg #8729 — target-file-size not respected](https://github.com/apache/iceberg/issues/8729) · [#10892 — Flink savepoint data loss](https://github.com/apache/iceberg/issues/10892) · [#6679 — change default distribution mode](https://github.com/apache/iceberg/issues/6679)
+- [trinodb/trino #26563 — slow planning with stats](https://github.com/trinodb/trino/issues/26563) · [Iceberg dev list — streaming upserts](https://www.mail-archive.com/dev@iceberg.apache.org/msg12513.html)
+- [IOMETE — Maintenance Runbook](https://iomete.com/resources/blog/iceberg-maintenance-runbook) · [Conduktor — Maintaining Iceberg](https://www.conduktor.io/glossary/maintaining-iceberg-tables-compaction-and-cleanup) · [Alex Merced — Hidden Pitfalls](https://dev.to/alexmercedcoder/apache-iceberg-table-optimization-8-hidden-pitfalls-compaction-and-partition-evolution-in-13f1)
+- [Dremio — Compaction](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/) · [DataEngineer Hub — Snowflake auto-clustering costs](https://dataengineerhub.blog/articles/snowflake-managed-iceberg-tables-complete-guide-2026) · [Confluent/Medium — catalog lock-in](https://medium.com/confluent/will-apache-iceberg-win-the-table-format-war-01f6ff0d556d)
+
+---
+
+## Economist perspective
+
+### What this perspective notices
+- **Optimization is spend-shifting, not a free win.** Every maintenance job converts a recurring *read* cost into a recurring *write/compute* cost. The question is never "is the table optimized?" but "does the compute I spend optimizing exceed the read compute I save?" — and the answer flips with query frequency.
+- **Hidden cost centers don't show on storage dashboards.** Manifest/metadata bloat and small-file overhead surface on the *compute* bill (S3 GETs, planning time), so teams watching only storage under-manage them.
+- **"Managed/auto" optimization is serverless compute with a markup** — billed continuously and opaquely; the vendor decides when to run it.
+- **The open-format movement is a competitive maneuver over the storage layer** — commoditize storage (low margin) to compete on engines (high margin).
+- **Egress and cross-engine reads are the lock-in that "no lock-in" reintroduces.**
+- **Incentives differ by who owns the storage** (Snowflake-managed vs customer-managed vs pure object store).
+
+### Key claims (each with a source)
+1. **Compaction/clustering compute can exceed read savings on low-traffic or high-churn tables** — Snowflake auto-clustering "consumes credits continuously… can exceed the query savings." ([Revefi — Snowflake Cost Optimization](https://www.revefi.com/blog/snowflake-cost-optimization))
+2. **Cadence is the core cost lever** — compaction/expiration "scheduled strategically to balance compute cost, data freshness, and operational safety." ([Dremio/Alex Merced — Cadence](https://medium.com/data-engineering-with-dremio/apache-iceberg-table-optimization-6-designing-the-ideal-cadence-for-compaction-and-snapshot-7354a94a61d1))
+3. **Metadata bloat is a compute cost and the cheapest win** — "manifests… show up on your compute bill." ([overcast — Cost Reduction Strategies](https://overcast.blog/11-apache-iceberg-cost-reduction-strategies-you-should-know-8de7acb14151))
+4. **Compaction strategy is a compute-cost decision** — binpack is cheaper CPU/memory; sort/z-order spends compute up front to buy pruning (capex vs opex). ([Amit Gilad — Sort vs Binpack](https://amitgilad.substack.com/p/cracking-the-ice-the-battle-between))
+5. **Managed optimization is metered as serverless jobs** — Databricks PO billed under the serverless jobs SKU (`billing_origin_product=PREDICTIVE_OPTIMIZATION`). ([Databricks — serverless billing](https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing))
+6. **Serverless DBUs carry a premium over classic compute** (~$0.70–0.95 vs $0.40–0.55/DBU), so managed-serverless vs DIY-classic is a real markup tradeoff. ([Revefi — Databricks Cost Optimization](https://www.revefi.com/blog/databricks-cost-optimization))
+7. **Vendors commoditize storage to compete on engines** — open formats let customers swap engines, shifting the battle to where vendors hold pricing power. ([Rill — Why Hyperscalers Bet on Managed Iceberg](https://www.rilldata.com/blog/the-open-table-format-revolution-why-hyperscalers-are-betting-on-managed-iceberg))
+8. **The Tabular acquisition prices control of the open standard in the billions** — ~$1–2B for ~40-person Tabular in a bidding war vs Snowflake/Confluent. ([TechCrunch](https://techcrunch.com/2024/08/14/databricks-reportedly-paid-2-billion-in-tabular-acquisition); [TechTarget](https://www.techtarget.com/searchdatamanagement/news/366588032/Databricks-1B-plus-Tabular-acquisition-adds-Iceberg-support))
+9. **Cross-engine reads reintroduce egress costs** — "your cloud storage provider bills you for egress when data files move across regions or cloud platforms." ([Snowflake — data transfer cost](https://docs.snowflake.com/en/user-guide/cost-understanding-data-transfer))
+10. **Per-request (GET) charges compound on small-file layouts** — links file-sizing properties directly to the bill. ([Akave — egress economics](https://akave.com/blog/snowflake-adopted-iceberg-for-vendor-independence---akave-makes-it-financially-viable))
+11. **Snapshot/orphan retention is a quiet storage-cost accrual** that maintenance reclaims. ([overcast — Cost Reduction Strategies](https://overcast.blog/11-apache-iceberg-cost-reduction-strategies-you-should-know-8de7acb14151))
+12. **The platform owning compaction captures the savings** — Amazon S3 Tables markets managed compaction cutting costs "by up to 90%," moving the margin to the storage vendor. ([AWS — S3 Tables compaction](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-s3-tables-reduce-compaction-costs/))
+
+### Where this perspective is limited / blind spots
+- Over-weights dollar cost; under-weights correctness, freshness, latency (cost-per-query ≠ value-per-query).
+- Assumes read savings are cleanly attributable to a maintenance job; in practice caching and shifting query patterns muddy the counterfactual.
+- Cynical about vendor motives in ways that can miss genuine architectural value.
+- Pricing is a moving target — cited figures are directional/date-stamped, not constants.
+- Ignores people/TCO cost — "DIY is cheaper on the bill" omits engineering/on-call time.
+
+### Sources
+- [Revefi — Snowflake Cost Optimization](https://www.revefi.com/blog/snowflake-cost-optimization) · [Databricks Cost Optimization](https://www.revefi.com/blog/databricks-cost-optimization)
+- [Dremio/Alex Merced — Cadence](https://medium.com/data-engineering-with-dremio/apache-iceberg-table-optimization-6-designing-the-ideal-cadence-for-compaction-and-snapshot-7354a94a61d1) · [Amit Gilad — Sort vs Binpack](https://amitgilad.substack.com/p/cracking-the-ice-the-battle-between) · [overcast — Cost Reduction](https://overcast.blog/11-apache-iceberg-cost-reduction-strategies-you-should-know-8de7acb14151)
+- [Databricks — serverless billing](https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing) · [Rill — Hyperscalers & Managed Iceberg](https://www.rilldata.com/blog/the-open-table-format-revolution-why-hyperscalers-are-betting-on-managed-iceberg)
+- [TechCrunch — Tabular $2B](https://techcrunch.com/2024/08/14/databricks-reportedly-paid-2-billion-in-tabular-acquisition) · [TechTarget — Tabular acquisition](https://www.techtarget.com/searchdatamanagement/news/366588032/Databricks-1B-plus-Tabular-acquisition-adds-Iceberg-support)
+- [Snowflake — data transfer cost](https://docs.snowflake.com/en/user-guide/cost-understanding-data-transfer) · [Akave — egress economics](https://akave.com/blog/snowflake-adopted-iceberg-for-vendor-independence---akave-makes-it-financially-viable) · [AWS — S3 Tables compaction](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-s3-tables-reduce-compaction-costs/) · [Flexera — Snowflake Iceberg 2026](https://www.flexera.com/blog/finops/snowflake-iceberg-table/)
+
+---
+
+## Historian perspective
+
+### What this perspective notices
+- Iceberg optimization is largely a re-implementation of 1980s–2000s analytical-database engineering on cheap object storage. Compaction, sort/clustering keys, multi-dimensional clustering, target file sizes — each has a named ancestor in MPP warehouses or the Hadoop/Hive era.
+- The recurring cycle: physical data layout is the dominant lever for analytical performance, and every generation rediscovers it. Row groups → extents → blocks → micro-partitions → Iceberg data files are the same idea under new names.
+- Iceberg's defining innovations are mostly reactions to specific Hive *mistakes*, not green-field invention (hidden partitioning, partition evolution, manifest metadata).
+- The table-format wars recapitulate the COW-vs-MOR / read-vs-write-optimized tension C-Store framed in 2005.
+- What's genuinely new is narrow: the **metadata layer** (snapshot/manifest tree enabling serializable commits, time travel, engine-agnostic tables over object stores) — not the layout optimizations.
+- "Automatic/hidden/self-tuning" is the perennial marketing frontier (DB2 MDC 2003 → Snowflake auto-clustering ~2016 → managed compaction 2024–25).
+
+### Key claims (each with a source)
+1. **Compaction is the HDFS/Hadoop "small files problem" merge relocated to object storage.** ([Partition Management in Hadoop](https://adirmashiach.medium.com/partition-management-in-hadoop-9ec2a6b2e9f0); [Airbnb — On Spark, Hive, and Small Files](https://medium.com/airbnb-engineering/on-spark-hive-and-small-files-an-in-depth-look-at-spark-partitioning-strategies-a9a364f908))
+2. **`rewrite_data_files` bin-pack is literally a small-files merge to a target size**, the direct descendant of Hadoop compaction. ([Dremio — Compaction](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/); [11 Compaction Optimizations](https://dev.to/jonisar/11-compaction-optimizations-for-iceberg-data-lakes-52h2))
+3. **Hidden partitioning fixes Hive's mistake of making the partition column an explicit physical part of the schema/path.** ([Delta Lake — Pros/cons of Hive-style partitioning](https://delta.io/blog/pros-cons-hive-style-partionining/))
+4. **Partition evolution is a band-aid for the same Hive wrong-key problem** — change strategy without rewriting history. ([Delta Lake — Hive-style partitioning](https://delta.io/blog/pros-cons-hive-style-partionining/))
+5. **Iceberg was created at Netflix (Blue, Weeks) because Hive couldn't guarantee correctness/atomicity; open-sourced to Apache Nov 2018.** ([SE Daily — Iceberg at Netflix](https://softwareengineeringdaily.com/2024/03/07/iceberg-at-netflix-and-beyond-with-ryan-blue/); [Strata 2018](https://conferences.oreilly.com/strata/strata-ny-2018/public/schedule/detail/69503.html); [Wikipedia](https://en.wikipedia.org/wiki/Apache_Iceberg))
+6. **The Hive Metastore's weaknesses are the named precedent the manifest/snapshot tree replaced.** ([lakeFS — Hive Metastore's Dilemma](https://lakefs.io/blog/hive-metastore-it-didnt-age-well/))
+7. **Z-order predates Iceberg by decades** — Morton 1966, BIGMIN range-query algorithm Tropf & Herzog 1981. ([Wikipedia — Z-order curve](https://en.wikipedia.org/wiki/Z-order_curve))
+8. **Multi-dimensional clustering shipped in IBM DB2 (MDC) at SIGMOD 2003** — block indexes for "partition elimination," conceptually identical to Z-order compaction. ([DB2 MDC, SIGMOD 2003](https://scispace.com/pdf/multi-dimensional-clustering-a-new-data-layout-scheme-in-db2-3o0gapyp0x.pdf); [Z-Order for Delta/Iceberg](https://ajaygupta-spark.medium.com/z-order-optimization-for-generic-multi-dimensional-predicates-cc316a50dcfd))
+9. **Iceberg sort-order/clustering is the lakehouse re-invention of Vertica/C-Store projections and Teradata presorting** (C-Store, VLDB 2005). ([C-Store](https://scispace.com/papers/c-store-a-column-oriented-dbms-4q4ob7krcm); [Vertica Projections](https://docs.vertica.com/23.3.x/en/admin/projections/))
+10. **Snowflake micro-partitions (50–500 MB immutable units + auto clustering metadata) are the immediate proprietary precedent** for the data-file + manifest min/max model; auto-clustering (~2016) is warehouse-native managed compaction. ([Snowflake — Micro-partitions & Clustering](https://docs.snowflake.com/en/user-guide/tables-clustering-micropartitions); [Automatic Clustering at Snowflake](https://www.snowflake.com/en/blog/engineering/automatic-clustering-at-snowflake/))
+11. **COW vs MOR is the read-vs-write-optimized tradeoff from C-Store/LSM, resurfaced via Hudi.** ([DZone — Hudi vs Delta vs Iceberg](https://dzone.com/articles/hudi-vs-delta-vs-iceberg-table-format); [C-Store](https://scispace.com/papers/c-store-a-column-oriented-dbms-4q4ob7krcm))
+12. **The format wars ended like prior standard fights — convergence/interop shims** (Delta UniForm, Apache XTable). ([The Register — final chapter?](https://www.theregister.com/software/2024/10/03/are-the-table-format-wars-entering-the-final-chapter/1112902); [End of Format Wars](https://medium.com/@parthiban.jaganathan/end-of-open-table-format-wars-delta-iceberg-and-hudi-towards-uniform-format-98593e7e67b0))
+
+### Where this perspective is limited / blind spots
+- Systematically underrates the genuinely novel metadata/commit layer (serializable, serverless-coordinated, engine-agnostic over object stores).
+- Flattens context: object-store economics + storage/compute separation + multi-engine ecosystem make an old idea materially different.
+- "It's all been done before" breeds false confidence — Z-order at petabyte scale with delete-file reconciliation raises new operational problems.
+- Lineage claims risk over-tidiness (convergent invention ≠ direct descent).
+- Under-weights the social/governance shift (open standard + multi-vendor catalogs).
+
+### Sources
+- [SE Daily — Iceberg at Netflix](https://softwareengineeringdaily.com/2024/03/07/iceberg-at-netflix-and-beyond-with-ryan-blue/) · [Strata 2018](https://conferences.oreilly.com/strata/strata-ny-2018/public/schedule/detail/69503.html) · [Wikipedia — Apache Iceberg](https://en.wikipedia.org/wiki/Apache_Iceberg)
+- [Delta Lake — Hive-style partitioning](https://delta.io/blog/pros-cons-hive-style-partionining/) · [lakeFS — Hive Metastore](https://lakefs.io/blog/hive-metastore-it-didnt-age-well/) · [Partition Management in Hadoop](https://adirmashiach.medium.com/partition-management-in-hadoop-9ec2a6b2e9f0) · [Airbnb — Small Files](https://medium.com/airbnb-engineering/on-spark-hive-and-small-files-an-in-depth-look-at-spark-partitioning-strategies-a9a364f908)
+- [Dremio — Compaction](https://www.dremio.com/blog/compaction-in-apache-iceberg-fine-tuning-your-iceberg-tables-data-files/) · [11 Compaction Optimizations](https://dev.to/jonisar/11-compaction-optimizations-for-iceberg-data-lakes-52h2)
+- [Wikipedia — Z-order curve](https://en.wikipedia.org/wiki/Z-order_curve) · [Z-Order for Delta/Iceberg](https://ajaygupta-spark.medium.com/z-order-optimization-for-generic-multi-dimensional-predicates-cc316a50dcfd) · [DB2 MDC SIGMOD 2003](https://scispace.com/pdf/multi-dimensional-clustering-a-new-data-layout-scheme-in-db2-3o0gapyp0x.pdf) · [C-Store VLDB 2005](https://scispace.com/papers/c-store-a-column-oriented-dbms-4q4ob7krcm) · [Vertica Projections](https://docs.vertica.com/23.3.x/en/admin/projections/)
+- [Snowflake — Micro-partitions](https://docs.snowflake.com/en/user-guide/tables-clustering-micropartitions) · [Automatic Clustering at Snowflake](https://www.snowflake.com/en/blog/engineering/automatic-clustering-at-snowflake/) · [DZone — Hudi vs Delta vs Iceberg](https://dzone.com/articles/hudi-vs-delta-vs-iceberg-table-format) · [The Register — format wars](https://www.theregister.com/software/2024/10/03/are-the-table-format-wars-entering-the-final-chapter/1112902) · [End of Format Wars](https://medium.com/@parthiban.jaganathan/end-of-open-table-format-wars-delta-iceberg-and-hudi-towards-uniform-format-98593e7e67b0)
+
+---
+
+## Academic perspective
+
+### What this perspective notices
+- The rigorous evidence base is thin and recent, and most of it benchmarks *formats against each other*, not *tuning knobs within a format*. Strongest peer-reviewed work (LST-Bench SIGMOD 2024, CIDR 2023 lakehouse study) compares Delta/Iceberg/Hudi as systems. Little isolates the marginal effect of a single Iceberg setting. Much day-to-day tuning advice rests on vendor blogs and folklore.
+- Where the theory *is* solid, it predates Iceberg (min/max zone-map skipping, data-order dependence of pruning, space-filling-curve clustering). Iceberg inherits these results.
+- The benefit of compaction is one of the few claims with direct, recent empirical backing (AutoComp SIGMOD 2025; LST-Bench).
+- Clustering benefit is real but workload-dependent, and this nuance is empirically supported — locality degrades as you add columns to a Z-order key, contradicting "Z-order everything."
+- The spec itself is the most reliable "academic-grade" artifact for the deletes story (v2 position/equality vs v3 deletion vectors).
+
+### Key claims (each with a source)
+1. **Small files measurably degrade performance/cost; compaction is the established remedy** — peer-reviewed, drawing on LinkedIn production. ([AutoComp, SIGMOD 2025](https://arxiv.org/abs/2504.04186))
+2. **Maintenance must be evaluated *over time*, not one-shot** — LST-Bench adds degradation-rate metrics because LST performance drifts with mutations/small files. ([LST-Bench, SIGMOD 2024](https://dl.acm.org/doi/10.1145/3639314) / [arXiv](https://arxiv.org/abs/2305.01120))
+3. **LST-Bench declines to crown a format winner** — the contribution is methodology, itself evidence that "format X is fastest" isn't robust. ([LST-Bench](https://arxiv.org/abs/2305.01120))
+4. **Pruning effectiveness is dominated by *data order*, not just having stats** — poor ordering makes zone maps near-useless. ([Columnar Storage Formats, VLDB 2023](https://www.vldb.org/pvldb/vol17/p148-zeng.pdf) / [arXiv](https://arxiv.org/abs/2304.05028))
+5. **Min/max pruning can be extremely effective when data is well-clustered** — Snowflake reports up to ~99.4% micro-partitions pruned; real queries more selective than synthetic benchmarks assume. ([Pruning in Snowflake, SIGMOD 2024](https://arxiv.org/abs/2504.11540))
+6. **Well-clustered layout also unlocks LIMIT/top-k and join pruning, not only filter pruning.** ([Pruning in Snowflake](https://arxiv.org/abs/2504.11540))
+7. **Z-order's advantage over linear sort is multi-dimensional but workload-dependent; locality decays with each added column** — basis for "don't Z-order columns you don't filter on." ([Space-filling Curves, arXiv](https://arxiv.org/pdf/2008.01684))
+8. **Hilbert curves preserve locality better than Z-order for 2+ dims** — the reason Databricks Liquid Clustering uses Hilbert. ([Space-filling Curves](https://arxiv.org/pdf/2008.01684); [Hudi — Z-Order & Hilbert](https://hudi.apache.org/blog/2021/12/29/hudi-zorder-and-hilbert-space-filling-curves/))
+9. **v3 deletion vectors bound delete-file growth vs v2 position deletes** — ≤1 DV (Roaring bitmap in Puffin) per data file per snapshot, superseding the old; design intent, end-to-end measurements still scarce. ([Iceberg Spec](https://iceberg.apache.org/spec/); [Puffin Spec](https://iceberg.apache.org/puffin-spec/))
+10. **COW/MOR is a formal write-amp vs read-amp tradeoff** — MoR read amplification grows ~linearly with accumulated deletes until compaction, which is why MoR *requires* maintenance. ([Iceberg Spec](https://iceberg.apache.org/spec/); [Dremio — COW vs MOR](https://www.dremio.com/blog/row-level-changes-on-the-lakehouse-copy-on-write-vs-merge-on-read-in-apache-iceberg/))
+11. **No universal "best" columnar layout** — Parquet vs ORC no clear winner; block compression can hurt end-to-end speed on modern hardware. ([Columnar Storage Formats, VLDB 2023](https://www.vldb.org/pvldb/vol17/p148-zeng.pdf))
+12. **Lakehouse metadata design materially affects performance and is a first-class research subject** — differing manifest/metadata layers drive different planning/skipping. ([Lakehouse Storage Systems, CIDR 2023](https://www.cidrdb.org/cidr2023/papers/p92-jain.pdf))
+
+### Where this perspective is limited / blind spots
+- Benchmarks rarely match production (Snowflake's own finding: synthetic benchmarks understate selectivity). Numbers like "99.4% pruned" are environment-specific, not portable.
+- The literature lags fast-moving tooling — v3 has little independent peer-reviewed evaluation yet.
+- Format-vs-format studies under-serve within-format tuning (the actual knobs operators need).
+- Engine coupling is often ignored — results entangled with Spark/Trino/Snowflake may not transfer.
+- Cost and write-side amplification are under-measured (AutoComp a notable exception).
+- Publication/source bias — many quantitative sources are vendor-authored.
+
+### Sources
+- [LST-Bench, SIGMOD 2024 (ACM DL)](https://dl.acm.org/doi/10.1145/3639314) / [arXiv 2305.01120](https://arxiv.org/abs/2305.01120) / [MSR blog](https://www.microsoft.com/en-us/research/blog/lst-bench-a-new-benchmark-tool-for-open-table-formats-in-the-data-lake/)
+- [AutoComp, SIGMOD 2025 (arXiv 2504.04186)](https://arxiv.org/abs/2504.04186) · [Pruning in Snowflake, SIGMOD 2024 (arXiv 2504.11540)](https://arxiv.org/abs/2504.11540)
+- [Columnar Storage Formats, VLDB 2023 (PDF)](https://www.vldb.org/pvldb/vol17/p148-zeng.pdf) / [arXiv 2304.05028](https://arxiv.org/abs/2304.05028) · [Lakehouse Storage Systems, CIDR 2023 (PDF)](https://www.cidrdb.org/cidr2023/papers/p92-jain.pdf)
+- [Space-filling Curves (arXiv 2008.01684)](https://arxiv.org/pdf/2008.01684) · [Hudi — Z-Order & Hilbert](https://hudi.apache.org/blog/2021/12/29/hudi-zorder-and-hilbert-space-filling-curves/)
+- [Apache Iceberg Spec](https://iceberg.apache.org/spec/) · [Puffin Spec](https://iceberg.apache.org/puffin-spec/) · [Dremio — COW vs MOR](https://www.dremio.com/blog/row-level-changes-on-the-lakehouse-copy-on-write-vs-merge-on-read-in-apache-iceberg/)
+
+→ Continue to [Phase 2 · Contradiction map](02-contradiction-map.md).

--- a/research/iceberg-optimization/storm/02-contradiction-map.md
+++ b/research/iceberg-optimization/storm/02-contradiction-map.md
@@ -1,0 +1,141 @@
+# Phase 2 — Contradiction map
+
+Comparing the five perspectives, where do they actually disagree, why, and how
+well-supported is each side? This is where the real uncertainty lives — and where
+the main playbook had to be careful not to state contested advice as settled.
+
+First, what they **agree** on (consensus is as important as conflict):
+
+- **Small files are a real, costly problem**, and **compaction is the
+  highest-impact remedy** — the one optimization with peer-reviewed backing
+  (Academic: AutoComp/LST-Bench; Practitioner; Historian: it's the HDFS merge).
+- **A bare Iceberg table is not self-maintaining** — without compaction,
+  expiration, orphan cleanup, and manifest rewrites it degrades (Practitioner,
+  Skeptic, Economist all agree; only the *who pays / is it worth it* differs).
+- **MoR shifts cost from write-time to read-time and therefore mandates
+  compaction** (Practitioner, Skeptic, Academic — the Academic frames it as a
+  formal write-amp/read-amp tradeoff).
+- **Physical layout must match query patterns**; statistics alone don't prune if
+  data order is wrong (Academic, Practitioner, Historian).
+- **Managed auto-optimization only covers tables the platform manages** — foreign
+  / external-catalog tables get nothing (Practitioner, Economist).
+
+Now the genuine contradictions:
+
+---
+
+### C1 · Is there a "right" target file size? (128–512 MB)
+
+| Side | Claim | Support |
+|---|---|---|
+| Practitioner | 128–512 MB is the practical band; 256 MB a sane default. | Vendor/practitioner docs (Dremio). **Medium.** |
+| Skeptic | The number is contested (128 vs 256 vs 512 all "recommended"), **and the knob is often not even honored** by writers. | GitHub issue #8729 + conflicting docs. **Medium-high** for "contested"; **high** for "not always honored." |
+| Academic | No controlled study isolates the optimal; the *real* driver is data **order**, not file size per se. | VLDB 2023 columnar study. **High** (for the order-dominance point). |
+
+**Resolution:** there is a defensible *default band*, but it is a starting point
+to validate, not a law — and you must **verify actual output file sizes**, since
+the target isn't guaranteed. The playbook already hedges this ([§2.3](../02-recommendations-table-properties.md#23-target-file-size)); the peer review strengthens the "verify, don't trust the knob" wording.
+
+---
+
+### C2 · Is Iceberg optimization worth the effort, or overhead cargo-cult?
+
+| Side | Claim | Support |
+|---|---|---|
+| Skeptic | At gigabyte scale Iceberg is "the new Hadoop" — indirection + mandatory maintenance is pure overhead; much tuning is cargo-culted. | Quesma, Data Eng Weekly, HN. **Medium** (opinion-heavy, but well-argued). |
+| Practitioner/Economist/Historian | The value (and the maintenance tax) is **real and scales with size, concurrency, and #engines**; at petabyte/multi-engine scale it earns its keep. | Netflix origin, production reports. **Medium-high.** |
+
+**Resolution:** not a true contradiction once you condition on **scale**. The
+cost/benefit flips with table size, query frequency, concurrency, and number of
+engines. This is a strong argument for the playbook's **analysis-first** stance:
+the profile (esp. scale + access frequency) decides whether a given optimization
+pays. Folded into peer review as an explicit "when *not* to optimize" note.
+
+---
+
+### C3 · Managed auto-optimization: convenience or runaway meter?
+
+| Side | Claim | Support |
+|---|---|---|
+| Practitioner | Managed platforms (Snowflake TOS, Databricks PO, Fivetran) remove the maintenance toil. | Vendor docs. **Medium** (vendor-sourced, opaque). |
+| Economist/Skeptic | It's **serverless compute billed continuously**, decided by the vendor; on cold or high-churn tables it can **cost more than the reads it accelerates**. | Snowflake/Databricks billing docs, FinOps blogs. **Medium-high.** |
+
+**Resolution:** both true — automation removes toil *and* introduces opaque,
+metered spend. The decision is economic, not just technical: enable it on
+frequently-queried tables; for cold/rarely-read tables, auto-clustering/compaction
+can be net-negative. The playbook mentioned "watch costs"; peer review elevates
+this to a first-class **cost gate** in the platform chapter.
+
+---
+
+### C4 · Streaming + compaction: complementary or in conflict?
+
+| Side | Claim | Support |
+|---|---|---|
+| Practitioner | Stream fast, **pair with aggressive downstream compaction** — standard architecture. | Iceberg docs, masterclass. **Medium-high.** |
+| Skeptic | High-frequency streaming commits (esp. delete files) are **"very likely to conflict with any ongoing compaction"** — so "just compact harder" creates commit-conflict churn. | Iceberg dev mailing list. **Medium.** |
+
+**Resolution:** real tension, not a clean win. "Compact aggressively" is right but
+**not free of write-side conflict risk**. Mitigations: partition-scoped
+compaction on disjoint partitions from the live writer, partial-progress commits,
+and raised commit-retry counts. This nuance was **missing** from the playbook's
+ingestion/maintenance chapters → added in peer review.
+
+---
+
+### C5 · "Z-order everything" vs workload-specific clustering
+
+| Side | Claim | Support |
+|---|---|---|
+| Common advice / some practitioners | Z-order multiple columns for multi-dim pruning. | Vendor blogs. **Low-medium.** |
+| Academic | Z-order helps **only** queries filtering the clustered columns; **locality decays with each added column**; **Hilbert > Z-order** for 2+ dims. | Space-filling-curve literature; Databricks' Hilbert switch. **High.** |
+
+**Resolution:** Academic wins on evidence. Z-order is not free and not universal —
+cluster only on columns that actually filter, and prefer the platform's modern
+curve (Databricks Liquid Clustering uses Hilbert). The playbook said "don't sort
+columns nobody filters" but didn't mention curve choice/locality decay → added.
+
+---
+
+### C6 · "Open, no lock-in" vs catalog/egress lock-in
+
+| Side | Claim | Support |
+|---|---|---|
+| Marketing / pro-Iceberg framing | Open format ⇒ no lock-in, pick any engine. | Vendor positioning. **Low** (as an absolute). |
+| Skeptic | **Catalog choice** is the real lock-in; the catalog vendor holds strategic power. | Confluent/Medium analysis. **Medium.** |
+| Economist | **Cross-engine/cross-region reads reintroduce egress + per-request costs** that the neutrality pitch omits. | Snowflake/AWS cost docs. **Medium-high.** |
+
+**Resolution:** "no lock-in" is overstated. Format openness is real; **catalog and
+egress economics are where lock-in/cost re-enters.** Out of scope for the
+optimization playbook's three categories, but a material caveat for the synthesis'
+"recommended actions" (catalog choice is a strategic decision, not a detail).
+
+---
+
+### C7 · Is any of this genuinely new?
+
+| Side | Claim | Support |
+|---|---|---|
+| Historian | Layout optimizations are 1980s–2005 DW/Hadoop ideas reborn (Z-order 1966, DB2 MDC 2003, C-Store 2005, Snowflake micro-partitions ~2016). | Primary lineage sources. **High.** |
+| Academic/others | The **metadata/commit layer** (serializable, serverless-coordinated, engine-agnostic over object storage) is the real discontinuity. | Iceberg spec, CIDR 2023. **High.** |
+
+**Resolution:** both true and complementary — the *optimizations* are old, the
+*substrate* (metadata layer over object stores) is new. Useful framing for the
+synthesis: trust the decades-old layout wisdom; treat the metadata layer as the
+genuinely novel (and still-maturing, e.g. v3) part.
+
+---
+
+## Open questions no single perspective resolved
+
+- **Quantified within-format tuning.** Nobody has rigorous numbers for "256 vs
+  512 MB on workload X" or "compact every 1 h vs 4 h." The Academic confirms this
+  gap exists; the playbook's numeric defaults are therefore *informed defaults to
+  measure against*, not validated optima.
+- **v3 deletion vectors' measured impact.** Design intent is clear (bound delete
+  growth, cut read amplification); independent end-to-end measurements are scarce.
+- **Real cost attribution of maintenance.** "Does this compaction pay for itself?"
+  is unanswered in general — caching and shifting query patterns defeat the
+  counterfactual. Argues for measuring per-table, not assuming.
+
+→ Continue to [Phase 3 · Synthesis briefing](03-synthesis-briefing.md).

--- a/research/iceberg-optimization/storm/03-synthesis-briefing.md
+++ b/research/iceberg-optimization/storm/03-synthesis-briefing.md
@@ -1,0 +1,102 @@
+# Phase 3 — Synthesis briefing
+
+A research briefing that combines the five perspectives and the contradiction map
+into findings, tradeoffs, a reliability ranking, and recommended actions. This is
+the bridge between the STORM research and the [main playbook](../README.md).
+
+## Bottom line
+
+Iceberg optimization is **layout + maintenance economics applied to one specific
+workload** — the optimizations themselves are decades-old database wisdom
+(Historian), only a few are empirically validated (Academic), and whether any of
+them pays off is conditional on scale, query frequency, and who runs/pays for the
+work (Economist, Skeptic). This is the strongest possible argument for the
+playbook's **analysis-first** method: the right settings are *derived per table*,
+not adopted from a defaults list. The biggest cross-perspective correction to
+conventional how-tos: **stop treating numeric defaults and "just turn on
+auto/just compact harder" as universal — condition them on evidence and cost.**
+
+## Main findings
+
+1. **Compaction is the load-bearing optimization** and the only one with rigorous
+   support. Small files genuinely hurt; compaction genuinely fixes it; everything
+   else is secondary tuning. (All five; Academic = peer-reviewed.)
+2. **Layout beats statistics.** Pruning is dominated by *data order*; min/max zone
+   maps are near-useless on poorly-ordered data. Sort/cluster on the columns
+   queries actually filter — and no more. (Academic, Practitioner.)
+3. **MoR is a deferred bill, not a discount.** It trades write cost for read
+   amplification that grows until compaction; equality deletes make this acute for
+   streaming CDC. Choose MoR for high-mutation workloads *and commit to the
+   maintenance*, or choose COW for read-heavy/low-mutation. (All; Skeptic flags
+   severity; Academic formalizes it.)
+4. **Defaults are starting points, not laws** — and some (target file size) aren't
+   even reliably honored by writers. Always verify actual output. (Skeptic,
+   Practitioner, Academic.)
+5. **Managed optimization is a cost decision, not a free button.** It removes toil
+   but bills as continuous serverless compute, scoped only to platform-managed
+   tables; on cold/high-churn tables it can be net-negative. (Economist, Skeptic,
+   Practitioner.)
+6. **The scale question gates everything.** At small scale, much of this is
+   overhead; the value rises with size, concurrency, and number of engines reading
+   one table. (Skeptic vs the rest — resolved by conditioning on scale.)
+7. **"Open / no lock-in" is overstated** — the lock-in and recurring cost move to
+   the **catalog** and **cross-engine egress**. (Skeptic, Economist.)
+8. **The metadata layer is the genuinely new (and least-proven) part.** Trust the
+   old layout wisdom; treat v3 deletion vectors/row lineage as promising but
+   not-yet-independently-measured. (Historian + Academic.)
+
+## Key tradeoffs
+
+| Tradeoff | Pole A | Pole B | Decide via |
+|---|---|---|---|
+| Write vs read cost | COW (clean reads, costly writes) | MoR (cheap writes, read tax) | mutation rate + read sensitivity (profile) |
+| Freshness vs file health | frequent commits (small files) | batched commits (lag) | latency SLA (interviews) |
+| Optimize-now compute vs read-savings | sort/z-order/cluster, frequent compaction | binpack-only, lazy maintenance | query frequency × table heat (economics) |
+| Toil vs control/cost-visibility | managed auto-optimization | DIY procedures | table heat + cost posture |
+| Layout specificity vs flexibility | tight partition/sort to current queries | looser layout | query stability + evolution risk |
+
+## Reliability ranking of the advice
+
+**Well-supported (act on it):**
+- Compact small files; it's the highest-impact, evidence-backed move.
+- Match sort/cluster keys to actual filter columns; order drives pruning.
+- MoR requires regular compaction; budget for it.
+- Maintenance is destructive and order-sensitive (compact → expire → orphan-remove
+  → rewrite manifests); keep the orphan safety window.
+- Managed optimization only covers platform-managed tables.
+
+**Directionally right but unquantified (treat as defaults to validate):**
+- Specific target file size (128–512 MB / 256 MB) — verify actual output.
+- Specific compaction/expiration cadences (1–4 h, daily/hourly) — tune per table.
+- `write.distribution-mode=hash` for partitioned batch — benchmark the shuffle cost.
+
+**Contested / context-dependent (decide per case):**
+- Whether to optimize at all (scale-gated).
+- Whether managed auto-optimization is worth it (cost-gated).
+- Z-order multiple columns (workload-gated; prefer Hilbert/Liquid Clustering where available).
+- "Compact aggressively" under heavy streaming (commit-conflict risk).
+
+**Vendor-sourced / unverified (quote with care):**
+- Specific cost figures ("up to 90%", DBU rates, "99.4% pruned", $1–2B Tabular).
+- Managed-platform internals (when/how aggressively auto-jobs run).
+
+## Recommended actions
+
+1. **Keep the analysis-first method** — the perspectives converge on "it depends on
+   the workload," which is exactly what the [Part I profile](../01-methodology-and-analysis.md)
+   captures. This is validated, not just stylistically nice.
+2. **Add a cost/scale gate before recommending any optimization** — a "when *not*
+   to optimize" check (cold tables, sub-scale tables, net-negative managed
+   clustering). Fold into the maintenance + platform chapters.
+3. **Harden the contested claims in the playbook** with explicit caveats:
+   target-file-size verification, Z-order locality decay + Hilbert, streaming↔
+   compaction commit conflicts. (Done in peer review.)
+4. **Label vendor numbers as unverified** in `SOURCES.md` and avoid quoting them as
+   fact. (Done.)
+5. **Treat catalog choice and egress as strategic** — note in the synthesis that
+   the deepest lock-in/cost is not the file format. (Noted; out of the three
+   optimization categories' scope but flagged.)
+6. **Prefer the few validated levers** (compaction, order-aware clustering) and
+   treat everything else as a hypothesis to measure against the Stage-2 baseline.
+
+→ Continue to [Phase 4 · Peer review](04-peer-review.md).

--- a/research/iceberg-optimization/storm/04-peer-review.md
+++ b/research/iceberg-optimization/storm/04-peer-review.md
@@ -87,6 +87,20 @@ facts without re-checking the primary source (many came from search snippets aft
 
 → Noted in [`../SOURCES.md`](../SOURCES.md).
 
+### Verification replay (what was re-checked with real reads)
+
+A follow-up pass attempted to re-fetch the flagged sources in full. The session's
+environment only reaches an **allowlisted set of domains** — GitHub works; arXiv,
+AWS, Snowflake/Databricks docs, VLDB, RisingWave, HN, and `api.firecrawl.dev` all
+return HTTP 403 — so only the **GitHub-sourced** claims could be verified by direct
+read. All four checked out exactly as cited (#8729 512 MB→~100 MB; #10892 Flink
+savepoint silent data loss; #13674 `rewrite_data_files` OOM + partial-progress/
+max-concurrent=1 mitigation; trinodb/trino #26563 planning 7 ms→~3 min with stats
+on). The vendor **cost/benchmark figures remain snippet-only** and unverifiable
+from here; closing that gap requires broadening the session's network policy or
+fetching from a less restricted environment. Firecrawl is not an option in this
+environment (no tool/key, and its API endpoint is blocked by the same allowlist).
+
 ## Confidence / reliability assessment
 
 - **High confidence:** the *method* (analysis-first), and the validated levers

--- a/research/iceberg-optimization/storm/04-peer-review.md
+++ b/research/iceberg-optimization/storm/04-peer-review.md
@@ -1,0 +1,105 @@
+# Phase 4 — Peer review
+
+A self-critique of the [synthesis briefing](03-synthesis-briefing.md) and the
+[main playbook](../README.md): strong claims, weak claims, biases, missing angles,
+and what still needs source verification — followed by the concrete corrections
+that were folded back into the playbook.
+
+## Strong claims (well-supported, keep)
+
+- **Compaction is the highest-impact, evidence-backed optimization.** Backed by
+  peer-reviewed work (AutoComp SIGMOD 2025, LST-Bench SIGMOD 2024) *and* every
+  practitioner source. Safe to state plainly.
+- **Pruning is dominated by data order, not just statistics.** VLDB 2023 columnar
+  study + Snowflake SIGMOD 2024. Strong.
+- **MoR defers cost to reads and mandates compaction.** Formalized (write-amp vs
+  read-amp) and observed across sources.
+- **Analysis-first is the right frame.** The five perspectives independently
+  converge on "it depends on the workload," which is precisely what the Part I
+  profile operationalizes. The method survives multi-perspective scrutiny.
+
+## Weak / over-stated claims (hedged or corrected)
+
+1. **Numeric defaults stated too confidently.** "128–512 MB", "256 MB default",
+   "compact every 1–4 h", "expire hourly" are *informed defaults*, not validated
+   optima — the Academic confirms no controlled study isolates them, and the
+   Skeptic shows the file-size knob isn't even reliably honored. → **Corrected:**
+   [§2.3](../02-recommendations-table-properties.md#23-target-file-size) now says
+   verify actual output and don't assume the knob worked; the synthesis reliability
+   ranking labels these as "validate, don't adopt."
+2. **"Z-order for multi-column pruning" presented as a clean win.** Locality decays
+   per added column and only helps queried columns; Hilbert is better for 2+ dims.
+   → **Corrected:** [§2.2](../02-recommendations-table-properties.md#22-sort-order--clustering)
+   now states the decay and the Hilbert/Liquid-Clustering point.
+3. **"Compact aggressively" for streaming, stated without the conflict caveat.**
+   High-frequency commits can conflict with in-flight compaction. → **Corrected:**
+   [§4.2](../04-recommendations-maintenance.md#42-compaction-the-highest-impact-operation)
+   adds the conflict + mitigations + the Flink savepoint data-loss warning.
+4. **Maintenance implied as unconditionally good.** It's a cost shift that only
+   pays off on hot tables. → **Corrected:** a **cost/scale gate ("when *not* to
+   optimize")** added to the [maintenance chapter intro](../04-recommendations-maintenance.md)
+   and a serverless-cost caveat to the
+   [Snowflake managed cell](../05-platform-playbooks.md).
+
+## Likely biases in the research
+
+- **Vendor-source skew.** Many quantitative claims trace to vendors (Snowflake,
+  Databricks, AWS, Microsoft, LinkedIn) who benchmark their own systems and choose
+  baselines. The Economist and Academic both flagged this.
+- **Negativity/survivorship bias in the Skeptic stream.** GitHub issues and HN
+  over-represent breakage; they don't quantify how often tables run fine.
+- **Recency skew.** The fetch environment blocked many primary pages (403s), so
+  some specifics rest on search snippets — a bias toward whatever the search index
+  surfaced, not the full text.
+- **JVM/Spark-tooling skew.** The mature maintenance procedures live in Spark, so
+  the advice leans Spark/Trino; PyIceberg and non-JVM clients are under-covered.
+
+## Missing angles (acknowledged, partly out of scope)
+
+- **Catalog choice & cross-engine egress** — the deepest lock-in/cost is the
+  *catalog* and *egress*, not the file format (Skeptic, Economist). Out of the
+  three optimization categories, but **flagged** in the synthesis "recommended
+  actions" so it isn't silently omitted.
+- **Concurrency/multi-writer correctness** beyond the basics — the playbook covers
+  optimistic concurrency and commit retries, but distributed multi-engine write
+  coordination is deeper than this book goes.
+- **v3 deletion vectors' *measured* impact** — design intent is clear; independent
+  end-to-end numbers are scarce. The book points to v3 as promising without
+  over-claiming, which the Academic supports.
+- **Security/governance (FGAC), schema-design-as-optimization** — touched only
+  lightly; arguably partition/schema *design* prevents more pain than any
+  post-hoc tuning (Practitioner blind-spot note).
+
+## Claims that still need source verification
+
+These are quoted in the perspectives but should **not** be republished as hard
+facts without re-checking the primary source (many came from search snippets after
+403s):
+
+- Specific cost figures: Amazon S3 Tables "up to 90%", serverless DBU rates
+  ($0.70–0.95 vs $0.40–0.55), GET pricing "$0.0004/1k", the "$4,500–7,000/mo"
+  example, the **$1–2B Tabular** price, Snowflake "~0.5–2 credits/GB/day."
+- Snowflake "**99.4%** micro-partitions pruned" (real paper, snippet-sourced).
+- Exact procedure defaults (`min-input-files=5`, `max-concurrent=5`,
+  `partial-progress=false`, **512 MB** target, **3-day** orphan window) — these are
+  corroborated across multiple sources and match the Apache docs, but worth a
+  final docs check before being treated as current.
+
+→ Noted in [`../SOURCES.md`](../SOURCES.md).
+
+## Confidence / reliability assessment
+
+- **High confidence:** the *method* (analysis-first), and the validated levers
+  (compaction, order-aware clustering, MoR-requires-maintenance, maintenance
+  order/safety). These survived all five perspectives.
+- **Medium confidence:** the specific numeric defaults and cadences — directionally
+  right, individually unvalidated; the playbook now frames them as defaults to
+  measure against.
+- **Low confidence / verify before quoting:** vendor cost figures, managed-platform
+  internals, and v3 performance magnitudes.
+
+**Net:** the playbook's *structure and method are robust*; the *numbers are
+hypotheses with citations*; and the four corrections above closed the gaps where
+the first draft stated contested advice as settled.
+
+← Back to [STORM overview](00-method.md) · [Main playbook](../README.md)


### PR DESCRIPTION
## Summary

Add a comprehensive research-backed playbook for optimizing Apache Iceberg tables across engines and platforms. This is a new research document collection, not a blog post, organized as a structured guide with methodology, recommendations, and platform-specific guidance.

## Changes

- **Part I (Methodology & Analysis)** — `01-methodology-and-analysis.md`: Five-stage workflow for deriving optimization decisions from evidence (query logs, table metadata, ingestion logs, user interviews). Includes reusable SQL queries and health-check templates.

- **Part II (Recommendations)** — Four chapters covering:
  - `02-recommendations-table-properties.md`: Partitioning, sort/clustering, file size, write distribution, COW vs MOR, format/compression
  - `03-recommendations-ingestion.md`: Ingestion models, commit cadence, write distribution control
  - `04-recommendations-maintenance.md`: Compaction, snapshot expiration, orphan-file removal, manifest rewriting
  - `05-platform-playbooks.md`: Platform-specific guidance (Databricks, Snowflake, bespoke Spark/Trino/PyIceberg, Flink, dbt)

- **Part II (Reference)** — `06-decision-matrices.md`: One-page cheat sheets mapping workload archetypes and diagnostic signals to settings.

- **STORM Research Layer** — `storm/` directory documenting the research methodology:
  - `00-method.md`: Overview of the Stanford STORM multi-perspective research method
  - `01-perspectives.md`: Five independent expert perspectives (Practitioner, Skeptic, Economist, Historian, Academic) with sources
  - `02-contradiction-map.md`: Where perspectives disagree and how well-supported each side is
  - `03-synthesis-briefing.md`: Findings, tradeoffs, reliability ranking, and recommended actions
  - `04-peer-review.md`: Self-critique of strong/weak claims and corrections folded back into the playbook

- **Supporting files**:
  - `README.md`: Navigation guide and how to use the playbook
  - `SOURCES.md`: Source attribution and verification notes

## Implementation notes

- The playbook is **analysis-first**: it derives optimization settings from per-table evidence (Stage 0–4 profile) rather than prescribing universal defaults.
- All numeric recommendations (e.g., "128–512 MB file size", "compact every 1–4 h") are labeled as informed defaults to validate, not laws, with caveats about when they don't apply.
- The STORM research layer is included verbatim to show the multi-perspective reasoning and contradiction resolution that informed the main playbook.
- Platform guidance is conditional on whether the platform manages the table (auto-maintains it) or merely reads it (you maintain it).

https://claude.ai/code/session_01VSERJhCnioX19isLH4BfDa