### PR TITLE
Record add_repo permission in local Claude Code settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(git add *)",
-      "Bash(git commit -m 'Update domain to itamar-weiss.com and add spouse info to about page *)"
+      "Bash(git commit -m 'Update domain to itamar-weiss.com and add spouse info to about page *)",
+      "mcp__bf7c680d-5fdc-5ef4-b4a0-abadb619bf0a__add_repo"
     ]
   }
 }


### PR DESCRIPTION
Trivial: records that the `add_repo` MCP tool call is allowed in `.claude/settings.local.json`, so future sessions don't need to re-request it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVLz2Gms21jzv8S6NE1XaT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVLz2Gms21jzv8S6NE1XaT)_