### PR TITLE
FPV viewer: social-media capture kit (8 share-ready videos)

### DIFF
--- a/research/fpv-viewer/README.md
+++ b/research/fpv-viewer/README.md
@@ -56,8 +56,10 @@ capture/
                         (the guided tour embedded in the post).
   capture_social.mjs    Playwright: record the three social-media source takes
                         (gallery scroll/search/filter, video playing, scene
-                        playback + orbit), each at 16:9 AND a native square
-                        viewport. Defaults to the LIVE site (override BASE).
+                        playing start->end TWICE — orbit sweeps on the first
+                        pass, untouched second pass), each at 16:9 AND a native
+                        square viewport. Defaults to the LIVE site (override
+                        BASE; ONLY=scene re-records one scenario).
   build_social.sh       capture_social.mjs + trim + encode -> out/social/ with
                         8 videos: {tour,gallery,video,scene} x {linkedin 1080sq,
                         twitter 1280x720}. Tour = the three clips cross-faded

--- a/research/fpv-viewer/README.md
+++ b/research/fpv-viewer/README.md
@@ -54,6 +54,14 @@ capture/
   build_demo.sh         Trim each recording to its action window, burn caption
                         pills, cross-fade -> public/img/fpv-viewer/viewer-demo.mp4
                         (the guided tour embedded in the post).
+  capture_social.mjs    Playwright: record the three social-media source takes
+                        (gallery scroll/search/filter, video playing, scene
+                        playback + orbit), each at 16:9 AND a native square
+                        viewport. Defaults to the LIVE site (override BASE).
+  build_social.sh       capture_social.mjs + trim + encode -> out/social/ with
+                        8 videos: {tour,gallery,video,scene} x {linkedin 1080sq,
+                        twitter 1280x720}. Tour = the three clips cross-faded
+                        with caption pills.
 ```
 
 The little gallery cards and the pipeline boxes drawn *inside* the schematics
@@ -71,6 +79,18 @@ thumbnails from local disk) — run `npm run dev` in `apps/fpv-viewer/` of the
 ```
 cd capture && ./build_demo.sh
 cp out/scene_still.png ../assets/biranit_scene_capture.png   # refresh social bg
+```
+
+## Social-media videos
+
+`build_social.sh` produces the 8 share-ready clips under `capture/out/social/`
+({tour, gallery, video, scene} × {LinkedIn 1080×1080, Twitter 1280×720}). It
+records from the **live site** by default, so it only needs Playwright + ffmpeg
+— no dev server:
+
+```
+cd capture && ./build_social.sh                 # live site
+BASE=http://localhost:5185 ./build_social.sh    # or against the dev server
 ```
 
 ## Regenerate

--- a/research/fpv-viewer/capture/build_social.sh
+++ b/research/fpv-viewer/capture/build_social.sh
@@ -21,7 +21,7 @@ node capture_social.mjs
 #    action) and encode per platform. Black pad bars are invisible on the
 #    app's black background. The scene take plays the scene start->end twice,
 #    so its window is measured by the capture script (2x duration + margin).
-GAL_S=13; VID_S=10.5
+GAL_S=15; VID_S=10.5
 SCN_S=$(cat out/social-src/scene_keep.txt 2>/dev/null || echo 27)
 TW="-vf scale=1280:720:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 21 -movflags +faststart -an"
 LI="-vf scale=1080:1080:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 20 -movflags +faststart -an"
@@ -76,4 +76,22 @@ tour twitter
 tour linkedin
 rm -f "$OUTDIR"/cap*.png
 
-echo "wrote 8 videos to $OUTDIR/"
+# 5. make every output loop seamlessly: dissolve its last F seconds into its
+#    first F seconds, so the trimmed clip's final frame equals its first frame
+#    and feed players can repeat it without a visible jump.
+loopify() { # $1 file
+  local f="$1" F=0.5 D OFF
+  D=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$f")
+  OFF=$(python3 -c "print(max(0.1, $D - 2*$F))")
+  ffmpeg -y -i "$f" -filter_complex "
+[0:v]split[a][b];
+[a]trim=start=$F,setpts=PTS-STARTPTS,fps=30[main];
+[b]trim=duration=$F,setpts=PTS-STARTPTS,fps=30[head];
+[main][head]xfade=transition=fade:duration=$F:offset=$OFF[v]
+" -map "[v]" -c:v libx264 -profile:v high -pix_fmt yuv420p \
+    -crf 20 -movflags +faststart -an "${f%.mp4}.loop.mp4"
+  mv "${f%.mp4}.loop.mp4" "$f"
+}
+for f in "$OUTDIR"/fpv-*.mp4; do loopify "$f"; done
+
+echo "wrote 8 loopable videos to $OUTDIR/"

--- a/research/fpv-viewer/capture/build_social.sh
+++ b/research/fpv-viewer/capture/build_social.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build the 8 social-media videos for the /fpv viewer from live captures:
+#
+#   out/social/fpv-tour-linkedin.mp4      1080x1080  gallery→video→scene tour
+#   out/social/fpv-tour-twitter.mp4       1280x720
+#   out/social/fpv-gallery-{linkedin,twitter}.mp4    scroll / search / filter
+#   out/social/fpv-video-{linkedin,twitter}.mp4      a clip playing in the player
+#   out/social/fpv-scene-{linkedin,twitter}.mp4      3-D scene playback + orbit
+#
+# Prereqs: Playwright + ffmpeg (same as build_demo.sh). Records from the LIVE
+# site by default; set BASE=http://localhost:5185 to use the local dev server.
+set -euo pipefail
+cd "$(dirname "$0")"
+OUTDIR=out/social
+mkdir -p "$OUTDIR"
+
+# 1. record the six source takes (3 scenarios x {16:9, square})
+node capture_social.mjs
+
+# 2. trim the setup dead-time (it's at the FRONT; keep the last N seconds of
+#    action) and encode per platform. Black pad bars are invisible on the
+#    app's black background.
+GAL_S=13; VID_S=10.5; SCN_S=12
+TW="-vf scale=1280:720:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 21 -movflags +faststart -an"
+LI="-vf scale=1080:1080:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 20 -movflags +faststart -an"
+
+src() { ls out/social-src/"$1"/*.webm; }
+ffmpeg -y -sseof -$GAL_S -i "$(src gallery-169)" $TW "$OUTDIR/fpv-gallery-twitter.mp4"
+ffmpeg -y -sseof -$GAL_S -i "$(src gallery-sq)"  $LI "$OUTDIR/fpv-gallery-linkedin.mp4"
+ffmpeg -y -sseof -$VID_S -i "$(src video-169)"   $TW "$OUTDIR/fpv-video-twitter.mp4"
+ffmpeg -y -sseof -$VID_S -i "$(src video-sq)"    $LI "$OUTDIR/fpv-video-linkedin.mp4"
+ffmpeg -y -sseof -$SCN_S -i "$(src scene-169)"   $TW "$OUTDIR/fpv-scene-twitter.mp4"
+ffmpeg -y -sseof -$SCN_S -i "$(src scene-sq)"    $LI "$OUTDIR/fpv-scene-linkedin.mp4"
+
+# 3. caption pills for the tour (drawtext isn't compiled into brew ffmpeg)
+python3 - <<'PY'
+from PIL import Image, ImageDraw, ImageFont
+import os
+FONTS = ["/System/Library/Fonts/Supplemental/Arial.ttf",
+         "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"]
+font = ImageFont.truetype(next(f for f in FONTS if os.path.exists(f)), 30)
+caps = [("out/social/cap0", "Browse the gallery"),
+        ("out/social/cap1", "Watch the flight, annotated"),
+        ("out/social/cap2", "Explore the 3-D scene")]
+for name, text in caps:
+    d = ImageDraw.Draw(Image.new("RGBA", (10, 10)))
+    l, t, r, b = d.textbbox((0, 0), text, font=font)
+    W, H = (r - l) + 44, (b - t) + 24
+    im = Image.new("RGBA", (W, H), (0, 0, 0, 0)); dr = ImageDraw.Draw(im)
+    dr.rounded_rectangle([0, 0, W - 1, H - 1], radius=H // 2,
+                         fill=(0, 0, 0, 160), outline=(255, 255, 255, 40), width=1)
+    dr.text((22 - l, 12 - t), text, font=font, fill=(255, 255, 255, 255))
+    im.save(name + ".png")
+PY
+
+# 4. tour = the three platform clips cross-faded with caption pills.
+#    Segment lengths are the trimmed durations above; offsets are cumulative
+#    minus the 0.5 s fades.
+tour() { # $1 platform suffix
+  local A="$OUTDIR/fpv-gallery-$1.mp4" B="$OUTDIR/fpv-video-$1.mp4" C="$OUTDIR/fpv-scene-$1.mp4"
+  local O1 O2
+  O1=$(python3 -c "print($GAL_S-0.5)"); O2=$(python3 -c "print($GAL_S+$VID_S-1.0)")
+  ffmpeg -y -i "$A" -i "$B" -i "$C" \
+    -i "$OUTDIR/cap0.png" -i "$OUTDIR/cap1.png" -i "$OUTDIR/cap2.png" -filter_complex "
+[0:v][3:v]overlay=40:40[c0];
+[1:v][4:v]overlay=40:40[c1];
+[2:v][5:v]overlay=40:40[c2];
+[c0][c1]xfade=transition=fade:duration=0.5:offset=$O1[x1];
+[x1][c2]xfade=transition=fade:duration=0.5:offset=$O2[v]
+" -map "[v]" -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 20 \
+    -movflags +faststart -an "$OUTDIR/fpv-tour-$1.mp4"
+}
+tour twitter
+tour linkedin
+rm -f "$OUTDIR"/cap*.png
+
+echo "wrote 8 videos to $OUTDIR/"

--- a/research/fpv-viewer/capture/build_social.sh
+++ b/research/fpv-viewer/capture/build_social.sh
@@ -19,8 +19,10 @@ node capture_social.mjs
 
 # 2. trim the setup dead-time (it's at the FRONT; keep the last N seconds of
 #    action) and encode per platform. Black pad bars are invisible on the
-#    app's black background.
-GAL_S=13; VID_S=10.5; SCN_S=12
+#    app's black background. The scene take plays the scene start->end twice,
+#    so its window is measured by the capture script (2x duration + margin).
+GAL_S=13; VID_S=10.5
+SCN_S=$(cat out/social-src/scene_keep.txt 2>/dev/null || echo 27)
 TW="-vf scale=1280:720:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 21 -movflags +faststart -an"
 LI="-vf scale=1080:1080:flags=lanczos,fps=30 -c:v libx264 -profile:v high -pix_fmt yuv420p -crf 20 -movflags +faststart -an"
 

--- a/research/fpv-viewer/capture/capture_social.mjs
+++ b/research/fpv-viewer/capture/capture_social.mjs
@@ -128,6 +128,8 @@ const sceneAction = async (page) => {
   const box = stage ? await stage.boundingBox()
                     : { x: 120, y: 210, width: 900, height: 460 };
   const cy = box.y + box.height * 0.52;
+  // fine-grained input (20 ms steps): OrbitControls damping interpolates the
+  // camera between events, so coarse input would show as catch-up pulses
   const drag = async (fromK, toK, steps, lift) => {
     await page.mouse.move(box.x + box.width * fromK, cy);
     await page.mouse.down();
@@ -135,7 +137,7 @@ const sceneAction = async (page) => {
       const k = fromK + (toK - fromK) * (i / steps);
       await page.mouse.move(box.x + box.width * k,
                             cy - Math.sin((i / steps) * Math.PI) * lift);
-      await sleep(55);
+      await sleep(20);
     }
     await page.mouse.up();
   };
@@ -160,9 +162,9 @@ const sceneAction = async (page) => {
   // pass 1: full playback with the orbit sweeps
   await clickPlay(); await waitPlaying();
   await sleep(1200);
-  await drag(0.62, 0.30, 60, 52);    // slow sweep left  (~3.3 s)
+  await drag(0.62, 0.30, 165, 52);   // slow sweep left  (~3.3 s)
   await sleep(800);
-  await drag(0.30, 0.58, 52, 34);    // gentle sweep back (~2.9 s)
+  await drag(0.30, 0.58, 145, 34);   // gentle sweep back (~2.9 s)
   await waitEnded();
   await sleep(600);
   // pass 2: restart from the beginning and play through untouched

--- a/research/fpv-viewer/capture/capture_social.mjs
+++ b/research/fpv-viewer/capture/capture_social.mjs
@@ -20,7 +20,7 @@ const BASE = (process.env.BASE || "https://www.itamarweiss.com/fpv").replace(/\/
 const SLUG = process.env.SLUG || "2026-05-26_anti_drone_platform_barashit.mp4";
 const FLIGHT_T = Number(process.env.FLIGHT_T || 8.2);
 const OUT = process.env.OUT || "./out/social-src";
-fs.rmSync(OUT, { recursive: true, force: true });
+if (!process.env.ONLY) fs.rmSync(OUT, { recursive: true, force: true });
 fs.mkdirSync(OUT, { recursive: true });
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -118,9 +118,10 @@ const sceneSetup = async (page, hideBars) => {
   }, { timeout: 60000 }).catch(() => {});
   await sleep(800);
 };
+// The scene plays start -> end TWICE per take. The player's own semantics make
+// this reliable: at the end the play button flips back to "Play", and clicking
+// it again resets the timeline to t0 (k.t>=t1-.05 -> k.t=t0 in SceneView).
 const sceneAction = async (page) => {
-  await page.evaluate(() => document.querySelector(".play-btn")?.click());
-  await sleep(1500);
   const stage = await page.$(".scene-stage");
   const box = stage ? await stage.boundingBox()
                     : { x: 120, y: 210, width: 900, height: 460 };
@@ -136,18 +137,51 @@ const sceneAction = async (page) => {
     }
     await page.mouse.up();
   };
+  const BTN = ".scene-controls .play-btn";
+  const clickPlay = () => page.evaluate((s) => document.querySelector(s)?.click(), BTN);
+  const waitPlaying = () => page.waitForFunction(
+    (s) => document.querySelector(s)?.getAttribute("aria-label") === "Pause",
+    BTN, { timeout: 8000 }).catch(() => {});
+  const waitEnded = () => page.waitForFunction(
+    (s) => document.querySelector(s)?.getAttribute("aria-label") === "Play",
+    BTN, { timeout: 60000 }).catch(() => {});
+
+  // record the scene's playback duration so build_social.sh can trim exactly
+  const total = await page.evaluate(() => {
+    const t = document.querySelector(".scene-controls .time-display")?.textContent || "";
+    const m = (t.split("/").pop() || "").trim().match(/(\d+):(\d+(?:\.\d+)?)/);
+    return m ? Number(m[1]) * 60 + Number(m[2]) : null;
+  });
+  if (total) fs.writeFileSync(`${OUT}/scene_keep.txt`,
+                              String((2 * total + 3.5).toFixed(1)));
+
+  // pass 1: full playback with the orbit sweeps
+  await clickPlay(); await waitPlaying();
+  await sleep(1200);
   await drag(0.62, 0.30, 60, 52);    // slow sweep left  (~3.3 s)
-  await sleep(1400);
+  await sleep(800);
   await drag(0.30, 0.58, 52, 34);    // gentle sweep back (~2.9 s)
-  await sleep(2200);                  // let playback finish the pass
+  await waitEnded();
+  await sleep(600);
+  // pass 2: restart from the beginning and play through untouched
+  await clickPlay(); await waitPlaying();
+  await waitEnded();
+  await sleep(800);
 };
 
 // ---- record every scenario at both aspect ratios ---------------------------
+// ONLY=gallery|video|scene re-records a single scenario while iterating.
+const ONLY = process.env.ONLY;
+const SCENARIOS = [
+  ["gallery", gallerySetup, galleryAction],
+  ["video",   videoSetup,   videoAction],
+  ["scene",   sceneSetup,   sceneAction],
+].filter(([n]) => !ONLY || n === ONLY);
 const VIEWPORTS = [["169", 1600, 900], ["sq", 1080, 1080]];
 for (const [tag, W, H] of VIEWPORTS) {
-  await record(`gallery-${tag}`, W, H, gallerySetup, galleryAction);
-  await record(`video-${tag}`,   W, H, videoSetup,   videoAction);
-  await record(`scene-${tag}`,   W, H, sceneSetup,   sceneAction);
+  for (const [name, setup, action] of SCENARIOS) {
+    await record(`${name}-${tag}`, W, H, setup, action);
+  }
 }
 
 await browser.close();

--- a/research/fpv-viewer/capture/capture_social.mjs
+++ b/research/fpv-viewer/capture/capture_social.mjs
@@ -1,0 +1,154 @@
+// Record the three social-media source clips (gallery / video / scene) from
+// the live viewer, each at TWO viewports:
+//   - 1600x900  (16:9, encoded to 1280x720 for Twitter/X)
+//   - 1080x1080 (native square layout, encoded 1:1 for LinkedIn)
+// The app is responsive, so the square take is a real square layout, not a crop.
+//
+// Env:
+//   BASE      viewer origin+path        (default https://www.itamarweiss.com/fpv)
+//   SLUG      demo clip                 (default the Biranit / Iron Dome strike)
+//   FLIGHT_T  seek time (s) for the video take — the first flight segment
+//   OUT       output dir                (default ./out/social-src)
+//   PW_CHROME optional Chromium executablePath override
+//
+// Run via build_social.sh, which also trims + encodes the 8 final MP4s.
+import pw from "playwright";
+import fs from "node:fs";
+const { chromium } = pw;
+
+const BASE = (process.env.BASE || "https://www.itamarweiss.com/fpv").replace(/\/$/, "");
+const SLUG = process.env.SLUG || "2026-05-26_anti_drone_platform_barashit.mp4";
+const FLIGHT_T = Number(process.env.FLIGHT_T || 8.2);
+const OUT = process.env.OUT || "./out/social-src";
+fs.rmSync(OUT, { recursive: true, force: true });
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.PW_CHROME || undefined,
+  args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader",
+         "--ignore-gpu-blocklist", "--enable-webgl", "--autoplay-policy=no-user-gesture-required"],
+});
+
+async function record(name, W, H, setup, action) {
+  const dir = `${OUT}/${name}`;
+  fs.mkdirSync(dir, { recursive: true });
+  const ctx = await browser.newContext({
+    viewport: { width: W, height: H }, deviceScaleFactor: 1,
+    recordVideo: { dir, size: { width: W, height: H } },
+  });
+  const page = await ctx.newPage();
+  page.on("console", (m) => { if (m.type() === "error") console.log(`[${name}] ERR`, m.text()); });
+  const hideBars = () => page.addStyleTag({
+    content: `::-webkit-scrollbar{width:0;height:0}html{scrollbar-width:none}`,
+  }).catch(() => {});
+  await setup(page, hideBars);
+  await action(page);
+  await ctx.close();
+  const webm = fs.readdirSync(dir).find((f) => f.endsWith(".webm"));
+  console.log(name, "->", webm);
+}
+
+// ---- Gallery: scroll, search, filter (action ≈ 13 s, keep last 13) ---------
+const gallerySetup = async (page, hideBars) => {
+  await page.goto(`${BASE}/#/`, { waitUntil: "domcontentloaded" });
+  await hideBars();
+  await page.waitForSelector(".video-card", { timeout: 20000 });
+  await page.waitForFunction(() => {
+    const imgs = [...document.querySelectorAll(".video-card img")].slice(0, 9);
+    return imgs.length >= 6 && imgs.every((i) => i.complete && i.naturalWidth > 0);
+  }, { timeout: 25000 }).catch(() => {});
+  await sleep(600);
+};
+const galleryAction = async (page) => {
+  const smoothScroll = (max, dur) => page.evaluate(async ({ max, dur }) => {
+    const y0 = window.scrollY, start = performance.now();
+    await new Promise((res) => {
+      const step = (t) => { const k = Math.min((t - start) / dur, 1);
+        window.scrollTo(0, y0 + (max - y0) * (0.5 - 0.5 * Math.cos(k * Math.PI)));
+        k < 1 ? requestAnimationFrame(step) : res(); };
+      requestAnimationFrame(step);
+    });
+  }, { max, dur });
+  await sleep(500);
+  await smoothScroll(1100, 3200);                        // browse down
+  await sleep(500);
+  await smoothScroll(0, 1400);                           // back to the toolbar
+  await sleep(300);
+  const search = page.locator('input[type="search"]');   // live search
+  await search.click().catch(() => {});
+  await search.pressSequentially("merkava", { delay: 110 }).catch(() => {});
+  await sleep(1400);
+  await search.fill("").catch(() => {});                 // clear
+  await sleep(500);
+  const btn = page.getByRole("button", { name: /3D scenes/i });  // filter
+  if (await btn.count()) await btn.first().click().catch(() => {});
+  await sleep(900);
+  await smoothScroll(600, 1800);
+  await sleep(700);
+};
+
+// ---- Video: seek to the first flight segment and let it play (keep last 10.5)
+const videoSetup = async (page, hideBars) => {
+  await page.goto(`${BASE}/#/video/${SLUG}`, { waitUntil: "domcontentloaded" });
+  await hideBars();
+  await page.waitForSelector("video", { timeout: 20000 });
+  await page.waitForFunction(() => {
+    const v = document.querySelector("video");
+    return v && v.readyState >= 2;
+  }, { timeout: 25000 }).catch(() => {});
+  await page.evaluate(async (t) => {
+    window.scrollTo(0, 0);
+    const v = document.querySelector("video");
+    if (v) { v.muted = true; v.currentTime = t; try { await v.play(); } catch {} }
+  }, FLIGHT_T);
+  await sleep(400);
+};
+const videoAction = async () => { await sleep(10200); };
+
+// ---- Scene: playback + a slow there-and-back orbit (keep last 12) ----------
+const sceneSetup = async (page, hideBars) => {
+  await page.goto(`${BASE}/#/scene/${SLUG}`, { waitUntil: "domcontentloaded" });
+  await hideBars();
+  await page.waitForFunction(() => {
+    const st = document.querySelector(".scene-status");
+    const cv = document.querySelector(".canvas-holder canvas");
+    return cv && (!st || !st.textContent);
+  }, { timeout: 60000 }).catch(() => {});
+  await sleep(800);
+};
+const sceneAction = async (page) => {
+  await page.evaluate(() => document.querySelector(".play-btn")?.click());
+  await sleep(1500);
+  const stage = await page.$(".scene-stage");
+  const box = stage ? await stage.boundingBox()
+                    : { x: 120, y: 210, width: 900, height: 460 };
+  const cy = box.y + box.height * 0.52;
+  const drag = async (fromK, toK, steps, lift) => {
+    await page.mouse.move(box.x + box.width * fromK, cy);
+    await page.mouse.down();
+    for (let i = 0; i <= steps; i++) {
+      const k = fromK + (toK - fromK) * (i / steps);
+      await page.mouse.move(box.x + box.width * k,
+                            cy - Math.sin((i / steps) * Math.PI) * lift);
+      await sleep(55);
+    }
+    await page.mouse.up();
+  };
+  await drag(0.62, 0.30, 60, 52);    // slow sweep left  (~3.3 s)
+  await sleep(1400);
+  await drag(0.30, 0.58, 52, 34);    // gentle sweep back (~2.9 s)
+  await sleep(2200);                  // let playback finish the pass
+};
+
+// ---- record every scenario at both aspect ratios ---------------------------
+const VIEWPORTS = [["169", 1600, 900], ["sq", 1080, 1080]];
+for (const [tag, W, H] of VIEWPORTS) {
+  await record(`gallery-${tag}`, W, H, gallerySetup, galleryAction);
+  await record(`video-${tag}`,   W, H, videoSetup,   videoAction);
+  await record(`scene-${tag}`,   W, H, sceneSetup,   sceneAction);
+}
+
+await browser.close();
+console.log("DONE");

--- a/research/fpv-viewer/capture/capture_social.mjs
+++ b/research/fpv-viewer/capture/capture_social.mjs
@@ -86,6 +86,8 @@ const galleryAction = async (page) => {
   if (await btn.count()) await btn.first().click().catch(() => {});
   await sleep(900);
   await smoothScroll(600, 1800);
+  await sleep(400);
+  await smoothScroll(0, 1200);   // end back at the top -> cleaner loop point
   await sleep(700);
 };
 


### PR DESCRIPTION
Adds a one-command pipeline for producing the social-media videos of the /fpv viewer, following the existing `capture/` conventions (`build_demo.sh` etc.):

```
cd research/fpv-viewer/capture && ./build_social.sh          # records from the LIVE site
BASE=http://localhost:5185 ./build_social.sh                 # or the local dev server
```

Writes 8 videos to `capture/out/social/`:

| clip | LinkedIn | Twitter/X |
|---|---|---|
| `fpv-tour-*` (gallery→video→scene, caption pills, cross-fades) | 1080×1080 | 1280×720 |
| `fpv-gallery-*` (scroll, live search typing, 3D-scenes filter) | 1080×1080 | 1280×720 |
| `fpv-video-*` (clip seeked to first flight segment, playing) | 1080×1080 | 1280×720 |
| `fpv-scene-*` (scene plays start→end **twice**: orbit sweeps on the first pass, untouched second pass) | 1080×1080 | 1280×720 |

Details:
- **Square LinkedIn takes are native**: each scenario is recorded twice, at a 1600×900 viewport (→ 1280×720) and at a real 1080×1080 viewport — the app's responsive layout reflows to a clean square, no cropping. Verified headlessly against the locally-served bundle.
- **Scene double-playback is driven by the player's own semantics** (verified in the SceneView bundle): at the end the play button flips back to "Play", and clicking it resets the timeline to t0. The script waits on the button's `aria-label`, restarts, and measures the scene's duration from the time display, writing `scene_keep.txt` so `build_social.sh` trims exactly 2×duration + margin.
- `ONLY=gallery|video|scene` re-records a single scenario while iterating.
- H.264 / yuv420p / 30 fps / `+faststart`, CRF 20 (LinkedIn) / 21 (Twitter), no audio track.

**Verified in this sandbox**: full mechanical dry-run against the locally-served `public/fpv/` bundle — all six recordings produced, script exits 0, square layout confirmed (3-column grid, filter click registers "65 of 151"). What could NOT be verified here is a run against the live site with real CDN data (this environment's egress policy blocks `itamarweiss.com` and the CloudFront host), so the first real run should be eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVLz2Gms21jzv8S6NE1XaT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVLz2Gms21jzv8S6NE1XaT)_