### PR TITLE
fpv capture kit: drop SwiftShader flags so headless capture uses the real GPU

### DIFF
--- a/research/fpv-viewer/capture/capture_social.mjs
+++ b/research/fpv-viewer/capture/capture_social.mjs
@@ -27,7 +27,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const browser = await chromium.launch({
   headless: true,
   executablePath: process.env.PW_CHROME || undefined,
-  args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader",
+  args: ["--use-gl=angle",
          "--ignore-gpu-blocklist", "--enable-webgl", "--autoplay-policy=no-user-gesture-required"],
 });
 


### PR DESCRIPTION
While producing the 8 social videos with `build_social.sh`, the 3-D scene takes showed the exact judder described in the capture-kit troubleshooting notes: the 1M-point cloud repainted only every ~12 frames (~2.5 fps) while the HUD moved smoothly — SwiftShader software WebGL was too slow for the scene.

On this Apple-Silicon machine, launching headless Chromium with plain `--use-gl=angle` (no `--use-angle=swiftshader --enable-unsafe-swiftshader`) selects the ANGLE Metal backend (`Apple M1`), and the recorded scene renders smoothly every frame. This is the remedy the troubleshooting section itself prescribes for machines with working GPU headless.

Verified by frame-diff analysis on the re-recorded clips (change on every frame, no 12-frame stepping) and by eyeballing contact sheets of all 8 outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)