### PR TITLE
fpv viewer: add GA4 with hash-route page views

### DIFF
--- a/public/fpv/index.html
+++ b/public/fpv/index.html
@@ -36,6 +36,30 @@
       content="https://www.itamarweiss.com/img/fpv-viewer/social.png"
     />
 
+    <!-- Google Analytics 4 — same property as the main site (components/Analytics.tsx).
+         This file is a build artifact of the dataset repo's apps/fpv-viewer; when
+         dropping in a new viewer build, re-apply this block (or add it upstream). -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-K7F22HB9SJ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag("js", new Date());
+      // The viewer is a hash-routed SPA (#/, #/video/:id, #/scene/:id). Fold the
+      // hash route into page_path on the initial view and on every hashchange,
+      // so gallery vs player vs 3-D scene usage is distinguishable in GA.
+      function fpvPagePath() {
+        return "/fpv/" + location.hash.replace(/^#\/?/, "");
+      }
+      gtag("config", "G-K7F22HB9SJ", { page_path: fpvPagePath() });
+      addEventListener("hashchange", function () {
+        gtag("event", "page_view", {
+          page_path: fpvPagePath(),
+          page_location: location.href,
+          page_title: document.title,
+        });
+      });
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!-- Geist for body text, Doto for the site title — same pairing as itamarweiss.com -->


### PR DESCRIPTION
The FPV viewer at `/fpv/` is a static SPA served straight from `public/`, so it never passes through the Next.js layout that injects GA on the rest of the site — it had no analytics at all.

This adds the site's GA4 property (`G-K7F22HB9SJ`, the same one `components/Analytics.tsx` loads from `NEXT_PUBLIC_GA_ID`) directly to `public/fpv/index.html`:

- Standard gtag bootstrap in `<head>`.
- The viewer is hash-routed (`#/`, `#/video/:id`, `#/scene/:id`), which GA4 doesn't track by default. The snippet folds the hash route into `page_path` (`/fpv/scene/<slug>` etc.) on the initial view and emits a `page_view` on every `hashchange`, so gallery vs player vs 3-D scene engagement is distinguishable in GA.

**Verified** with a local Playwright smoke test: initial `config` carries the hash-derived `page_path`, hash navigation pushes `page_view` events with the new path, and the app mounts with no page errors.

**Caveat:** `public/fpv/index.html` is a build artifact of the dataset repo's `apps/fpv-viewer`. If a new viewer build is dropped in, this block must be re-applied — the durable home for it is the viewer's source `index.html` upstream (the comment in the file says so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)