### PR TITLE
Resolve FPV legacy slugs from dataset redirects

### DIFF
--- a/app/fpv/scene/[slug]/page.tsx
+++ b/app/fpv/scene/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import {
   getSceneVideos,
   getVideoBySlug,
+  resolveLegacySlug,
   videoSubtitle,
   videoTitle,
 } from "@/lib/fpv/data";
@@ -38,6 +39,11 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 export default async function ScenePage({ params }: Params) {
   const { slug } = await params;
   const v = await getVideoBySlug(slug);
-  if (!v || !v.scenePath) notFound();
+  if (!v) {
+    const currentSlug = await resolveLegacySlug(slug);
+    if (currentSlug) permanentRedirect(sceneHref(currentSlug));
+    notFound();
+  }
+  if (!v.scenePath) notFound();
   return <SceneView video={v} />;
 }

--- a/app/fpv/video/[slug]/page.tsx
+++ b/app/fpv/video/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import {
   getVideos,
   getVideoBySlug,
+  resolveLegacySlug,
   videoSubtitle,
   videoTitle,
 } from "@/lib/fpv/data";
@@ -38,6 +39,10 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 export default async function VideoPage({ params }: Params) {
   const { slug } = await params;
   const v = await getVideoBySlug(slug);
-  if (!v) notFound();
+  if (!v) {
+    const currentSlug = await resolveLegacySlug(slug);
+    if (currentSlug) permanentRedirect(videoHref(currentSlug));
+    notFound();
+  }
   return <VideoView video={v} />;
 }

--- a/lib/fpv/config.ts
+++ b/lib/fpv/config.ts
@@ -7,3 +7,4 @@ export const CDN_BASE = CDN;
 export const SCENE_BASE = `${CDN}/scenes`;
 export const THUMB_BASE = `${CDN}/thumbnails`;
 export const DATA_URL = `${CDN}/data/videos.json`;
+export const REDIRECTS_URL = `${CDN}/data/redirects.json`;

--- a/lib/fpv/data.ts
+++ b/lib/fpv/data.ts
@@ -1,6 +1,6 @@
 import "server-only";
-import { DATA_URL } from "./config";
-import type { Dataset, VideoRecord } from "./types";
+import { DATA_URL, REDIRECTS_URL } from "./config";
+import type { Dataset, RedirectManifest, VideoRecord } from "./types";
 
 // Fetch the published manifest server-side. Cached for 5 minutes so new videos
 // / scenes show up within minutes of a `publish-web` without a redeploy, and so
@@ -18,9 +18,33 @@ export async function getVideos(): Promise<VideoRecord[]> {
   );
 }
 
-export async function getVideoBySlug(slug: string): Promise<VideoRecord | null> {
+export async function getVideoBySlug(
+  slug: string,
+): Promise<VideoRecord | null> {
   const videos = await getVideos();
   return videos.find((v) => v.slug === slug) ?? null;
+}
+
+export async function resolveLegacySlug(slug: string): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetch(REDIRECTS_URL, { next: { revalidate: 300 } });
+  } catch {
+    return null;
+  }
+  // This permits the website to deploy before the registry is first published.
+  if (!res.ok) return null;
+  const payload = (await res.json()) as RedirectManifest;
+  const redirects = new Map(
+    payload.redirects.map((item) => [item.from, item.to]),
+  );
+  const visited = new Set<string>();
+  let current = slug;
+  while (redirects.has(current) && !visited.has(current)) {
+    visited.add(current);
+    current = redirects.get(current)!;
+  }
+  return current === slug ? null : current;
 }
 
 export async function getSceneVideos(): Promise<VideoRecord[]> {

--- a/lib/fpv/types.ts
+++ b/lib/fpv/types.ts
@@ -25,6 +25,19 @@ export type Dataset = {
   videos: VideoRecord[];
 };
 
+export type DatasetRedirect = {
+  from: string;
+  to: string;
+  created_at: string;
+  review_after?: string;
+  reason: string;
+};
+
+export type RedirectManifest = {
+  schema_version: 1;
+  redirects: DatasetRedirect[];
+};
+
 // Segment marker colors — same legend as the annotator.
 export const SEGMENT_TYPES: Record<string, { label: string; color: string }> = {
   banner_start: { label: "Banner", color: "#4a9eff" },


### PR DESCRIPTION
## Summary
- read the dataset-owned redirect registry at runtime
- permanently redirect legacy video and scene routes
- tolerate the registry being absent during the no-downtime rollout

## Verification
- `npx tsc --noEmit`
- `npm run build`

## Rollout order
Deploy this website change before publishing `data/redirects.json` from the dataset repo.