### PR TITLE
Add automatic FPV dataset revalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 # Set this in Vercel → Project → Settings → Environment Variables for production.
 # When unset, no analytics script is emitted.
 NEXT_PUBLIC_GA_ID=
+
+# Shared secret used by the dataset publisher to invalidate the FPV viewer's
+# server-side manifest and route caches after a successful data publish.
+FPV_REVALIDATE_TOKEN=

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ npm run start    # serve the production build
 | --- | --- |
 | Site title / URL / socials | `lib/site.ts` |
 | Google Analytics 4 ID | `NEXT_PUBLIC_GA_ID` env var (see `.env.example`) |
+| FPV publish revalidation | `FPV_REVALIDATE_TOKEN` env var (see below) |
 | Legacy URL redirects | generated in `lib/redirects.ts` from each post |
 
 ## Deploying to Vercel
@@ -103,6 +104,14 @@ npm run start    # serve the production build
    attached so it 301-redirects to the new domain (preserving SEO).
 
 Every push to `master` triggers a Vercel production deploy.
+
+## FPV Dataset Revalidation
+
+The FPV dataset publisher calls `POST /api/fpv/revalidate` after uploading the
+new CloudFront manifest. Set `FPV_REVALIDATE_TOKEN` in Vercel's Production and
+Preview environments, then store the same value as `FPV_REVALIDATE_TOKEN` in
+the dataset repository's GitHub Actions secrets. This invalidates the tagged
+manifest fetch and the FPV gallery, video, and scene pages without a redeploy.
 
 ## Google Analytics 4
 

--- a/app/api/fpv/revalidate/route.ts
+++ b/app/api/fpv/revalidate/route.ts
@@ -1,0 +1,24 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+import { FPV_DATA_TAG } from "@/lib/fpv/data";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const token = process.env.FPV_REVALIDATE_TOKEN;
+  const authorization = request.headers.get("authorization");
+
+  if (!token) {
+    return NextResponse.json({ error: "FPV revalidation is not configured" }, { status: 503 });
+  }
+  if (authorization !== `Bearer ${token}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag(FPV_DATA_TAG);
+  revalidatePath("/fpv");
+  revalidatePath("/fpv/video/[slug]", "page");
+  revalidatePath("/fpv/scene/[slug]", "page");
+
+  return NextResponse.json({ revalidated: true, tag: FPV_DATA_TAG });
+}

--- a/lib/fpv/data.ts
+++ b/lib/fpv/data.ts
@@ -2,11 +2,13 @@ import "server-only";
 import { DATA_URL, REDIRECTS_URL } from "./config";
 import type { Dataset, RedirectManifest, VideoRecord } from "./types";
 
+export const FPV_DATA_TAG = "fpv-dataset";
+
 // Fetch the published manifest server-side. Cached for 5 minutes so new videos
 // / scenes show up within minutes of a `publish-web` without a redeploy, and so
 // generateMetadata / the page / the OG image share one request per revalidation.
 export async function getDataset(): Promise<Dataset> {
-  const res = await fetch(DATA_URL, { next: { revalidate: 300 } });
+  const res = await fetch(DATA_URL, { next: { revalidate: 300, tags: [FPV_DATA_TAG] } });
   if (!res.ok) throw new Error(`FPV manifest HTTP ${res.status}`);
   return (await res.json()) as Dataset;
 }


### PR DESCRIPTION
## What changed
- Tag the server-side CloudFront manifest fetch.
- Add a token-protected `POST /api/fpv/revalidate` endpoint that invalidates the manifest tag and FPV gallery, video, and scene routes.
- Document the shared `FPV_REVALIDATE_TOKEN` setup for Vercel and the dataset publisher.

## Verification
- `npx tsc --noEmit`

The dataset workflow wiring will follow once the production Vercel project has the corresponding environment variable.