### PR TITLE
Add starred 3D scene UI

### DIFF
--- a/app/fpv/fpv.scss
+++ b/app/fpv/fpv.scss
@@ -164,6 +164,34 @@
     padding: 2px 6px;
     border-radius: 4px;
   }
+  .scene-star-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: #f3c654;
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .scene-star-badge svg {
+    width: 14px;
+    height: 14px;
+    fill: currentColor;
+  }
+  .scene-star-badge.compact {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    width: 25px;
+    height: 25px;
+    justify-content: center;
+    border: 1px solid rgba(243, 198, 84, 0.7);
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.76);
+  }
+  .scene-star-badge.compact svg {
+    width: 15px;
+    height: 15px;
+  }
   .video-card .title {
     font-size: 14.5px;
     font-weight: 500;
@@ -246,6 +274,37 @@
   .toolbar-btn.active {
     border-color: var(--brand);
     color: var(--brand);
+  }
+  .scene-filter {
+    display: inline-flex;
+    min-height: 36px;
+    overflow: hidden;
+    border: 1px solid var(--hairline);
+    border-radius: 6px;
+    background: var(--surface);
+  }
+  .scene-filter button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0 10px;
+    border: 0;
+    border-right: 1px solid var(--hairline);
+    background: transparent;
+    color: var(--grey);
+    font: 500 13px var(--font-sans);
+    cursor: pointer;
+  }
+  .scene-filter button:last-child { border-right: 0; }
+  .scene-filter button:hover { color: #fff; }
+  .scene-filter button.active { background: #222; color: #fff; }
+  .scene-filter .scene-star-badge.compact {
+    position: static;
+    width: auto;
+    height: auto;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
   }
 
   /* Video view — YouTube-mobile-style: player first, compact headline below. */
@@ -347,6 +406,10 @@
   }
   .video-headline .view-meta {
     margin: 0 0 8px;
+  }
+  .video-headline > .scene-star-badge,
+  .scene-view > .scene-star-badge {
+    margin: 0 0 10px;
   }
   .icon-link {
     display: inline-flex;

--- a/components/fpv/Gallery.tsx
+++ b/components/fpv/Gallery.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { VideoRecord } from "@/lib/fpv/types";
 import { THUMB_BASE } from "@/lib/fpv/config";
 import { sceneHref, videoHref } from "@/lib/fpv/paths";
+import { SceneStarBadge } from "./SceneStarBadge";
 
 const PlayIcon = () => (
   <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden>
@@ -71,11 +72,12 @@ function Thumb({ video }: { video: VideoRecord }) {
         />
       ) : null}
       {video.scenePath ? <span className="badge-3d">3D scene</span> : null}
+      {video.sceneStarred ? <SceneStarBadge compact /> : null}
     </Link>
   );
 }
 
-type SceneFilter = "all" | "with";
+type SceneFilter = "all" | "with" | "starred";
 type SortDir = "desc" | "asc";
 
 type GalleryContentsProps = {
@@ -85,7 +87,7 @@ type GalleryContentsProps = {
   sceneFilter: SceneFilter;
   onQueryChange?: (query: string) => void;
   onSortChange?: () => void;
-  onSceneFilterChange?: () => void;
+  onSceneFilterChange?: (filter: SceneFilter) => void;
 };
 
 function GalleryContents({
@@ -101,6 +103,7 @@ function GalleryContents({
     const q = query.trim().toLowerCase();
     const list = videos.filter((v) => {
       if (sceneFilter === "with" && !v.scenePath) return false;
+      if (sceneFilter === "starred" && !v.sceneStarred) return false;
       if (!q) return true;
       return `${v.description} ${v.town} ${v.date} ${v.videoFile}`.toLowerCase().includes(q);
     });
@@ -135,15 +138,17 @@ function GalleryContents({
         >
           Date <ArrowIcon dir={sort} />
         </button>
-        <button
-          type="button"
-          className={`toolbar-btn${sceneFilter === "with" ? " active" : ""}`}
-          onClick={onSceneFilterChange}
-          aria-pressed={sceneFilter === "with"}
-          title="Only videos with a reconstructed 3D scene"
-        >
-          <GlobeIcon /> 3D scenes
-        </button>
+        <div className="scene-filter" aria-label="Scene filter">
+          <button type="button" className={sceneFilter === "all" ? "active" : ""} onClick={() => onSceneFilterChange?.("all")}>
+            All
+          </button>
+          <button type="button" className={sceneFilter === "with" ? "active" : ""} onClick={() => onSceneFilterChange?.("with")}>
+            <GlobeIcon /> 3D
+          </button>
+          <button type="button" className={sceneFilter === "starred" ? "active" : ""} onClick={() => onSceneFilterChange?.("starred")}>
+            <SceneStarBadge compact /> Starred
+          </button>
+        </div>
         <span className="gallery-count">
           {filtered.length === videos.length
             ? `${videos.length} videos`
@@ -190,7 +195,7 @@ export function Gallery({ videos }: { videos: VideoRecord[] }) {
   const paramQuery = searchParams.get("q") ?? "";
   const paramSort: SortDir = searchParams.get("sort") === "asc" ? "asc" : "desc";
   const paramSceneFilter: SceneFilter =
-    searchParams.get("scene") === "with" ? "with" : "all";
+    searchParams.get("scene") === "starred" ? "starred" : searchParams.get("scene") === "with" ? "with" : "all";
   const [query, setQuery] = useState(paramQuery);
   const [sort, setSort] = useState<SortDir>(paramSort);
   const [sceneFilter, setSceneFilter] = useState<SceneFilter>(paramSceneFilter);
@@ -229,10 +234,9 @@ export function Gallery({ videos }: { videos: VideoRecord[] }) {
         setSort(nextSort);
         updateParam("sort", nextSort === "asc" ? "asc" : undefined);
       }}
-      onSceneFilterChange={() => {
-        const nextSceneFilter = sceneFilter === "all" ? "with" : "all";
+      onSceneFilterChange={(nextSceneFilter) => {
         setSceneFilter(nextSceneFilter);
-        updateParam("scene", nextSceneFilter === "with" ? "with" : undefined);
+        updateParam("scene", nextSceneFilter === "all" ? undefined : nextSceneFilter);
       }}
     />
   );

--- a/components/fpv/SceneStarBadge.tsx
+++ b/components/fpv/SceneStarBadge.tsx
@@ -1,0 +1,18 @@
+type SceneStarBadgeProps = {
+  compact?: boolean;
+};
+
+export function SceneStarBadge({ compact = false }: SceneStarBadgeProps) {
+  return (
+    <span
+      className={`scene-star-badge${compact ? " compact" : ""}`}
+      title="Starred 3D scene"
+      aria-label="Starred 3D scene"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="m12 3.8 2.55 5.16 5.7.83-4.13 4.03.98 5.68L12 16.82 6.9 19.5l.98-5.68-4.13-4.03 5.7-.83L12 3.8Z" />
+      </svg>
+      {compact ? null : "Starred 3D scene"}
+    </span>
+  );
+}

--- a/components/fpv/SceneView.tsx
+++ b/components/fpv/SceneView.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { VideoRecord } from "@/lib/fpv/types";
 import { SCENE_BASE } from "@/lib/fpv/config";
 import { galleryHref, videoHref } from "@/lib/fpv/paths";
+import { SceneStarBadge } from "./SceneStarBadge";
 import {
   ReadOnlySceneViewer,
   type SceneFrame,
@@ -275,6 +276,7 @@ export function SceneView({ video }: { video: VideoRecord }) {
         {video.town ? ` · ${video.town}` : ""} · 3D reconstruction
         {stats ? ` · ${stats.pointCount.toLocaleString()} points · ${stats.frames} camera poses` : ""}
       </p>
+      {video.sceneStarred ? <SceneStarBadge /> : null}
       {stats && !stats.calibrated ? (
         <div className="scale-warning">⚠ Uncalibrated scale — relative units</div>
       ) : null}

--- a/components/fpv/VideoView.tsx
+++ b/components/fpv/VideoView.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { VideoRecord } from "@/lib/fpv/types";
 import { SEGMENT_TYPES } from "@/lib/fpv/types";
 import { galleryHref, sceneHref } from "@/lib/fpv/paths";
+import { SceneStarBadge } from "./SceneStarBadge";
 
 const FPS = 30; // frame-step size for ,/. and the ±1f buttons
 
@@ -209,6 +210,7 @@ export function VideoView({ video }: { video: VideoRecord }) {
           {video.date}
           {video.town ? ` · ${video.town}` : ""}
         </p>
+        {video.sceneStarred ? <SceneStarBadge /> : null}
         <div className="view-actions">
           {video.scenePath ? <Link href={sceneHref(video.slug)}>View 3D scene →</Link> : null}
           <a

--- a/lib/fpv/types.ts
+++ b/lib/fpv/types.ts
@@ -16,6 +16,7 @@ export type VideoRecord = {
   blur: string | null;
   scenePath: string | null; // "<stem>/<sceneId>" under the scenes base
   scenePaths: string[] | null; // all scene variants for this video (canonical first)
+  sceneStarred: boolean;
   segments: SegmentMarker[] | null;
   annotationAuto: boolean | null;
 };


### PR DESCRIPTION
## Summary
- add a persistent `scene=starred` FPV gallery filter
- mark starred scenes on gallery thumbnails, video pages, and scene pages
- consume the dataset catalog’s new `sceneStarred` field

## Verification
- `next lint`
- local FPV gallery confirms the Starred control and query-state wiring

## Note
- production `next build` compiles this change but currently fails while prerendering the existing `/500` page with a React `useContext` error.