### PR TITLE
Fix ENOENT on /sitemap.xml: ship content/ with the serverless bundle

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,17 @@ const nextConfig: NextConfig = {
   // Keep that behaviour so canonical URLs stay consistent.
   trailingSlash: true,
 
+  // `lib/posts.ts` reads content/posts/*.md with fs.readdirSync at request
+  // time, but Next's build tracer can't see through a runtime readdir, so the
+  // markdown never lands in the serverless bundle. Routes that are fully
+  // prerendered don't care; /sitemap.xml does, because fetching the FPV
+  // manifest gives it a 5-minute revalidate and it re-runs in the Lambda
+  // (ENOENT scandir '/var/task/content/posts'). Ship the content directory
+  // with every function so any route can read it at runtime.
+  outputFileTracingIncludes: {
+    "/**": ["./content/**/*"],
+  },
+
   // Embedded static apps living under public/<name>/ are served at their
   // directory URL. The Sun–Earth WebGL demo (public/solar-system/) is
   // pre-built and committed; the photo-geolocation tool (public/photo-


### PR DESCRIPTION
## The error

```
Error: ENOENT: no such file or directory, scandir '/var/task/content/posts'
  at .next/server/app/sitemap.xml/route.js
```

## Why it started

`app/sitemap.ts` now `await`s `getVideos()`, and `lib/fpv/data.ts` fetches the FPV manifest with `{ next: { revalidate: 300 } }`. That revalidate propagates to the route, so `/sitemap.xml` went from *fully prerendered* to *ISR* — the build output confirms it (`Revalidate 5m`). Every 5 minutes it re-runs inside the Vercel function, where it calls `getAllPosts()` → `fs.readdirSync(content/posts)`.

Next's build tracer can't see through a runtime `readdirSync`, so the markdown was never copied into that function's bundle. Every other content-reading route is fully prerendered, which is why only the sitemap blew up.

## The fix

`outputFileTracingIncludes` for `./content/**/*` — 244 KB of markdown, shipped with every function.

## Verification

`.nft.json` file traces (what Vercel uses to assemble each Lambda), before → after:

| route | before | after |
|---|---|---|
| `/sitemap.xml` | **0** content files | 25 |
| `/feed.xml` | 25 | 25 |
| `/blog/[slug]` | 25 | 25 |

`next build` clean, and `next start` serves `/sitemap.xml` with 275 `<url>` entries and `/feed.xml` with 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)