### PR TITLE
Serve 410 for FPV videos withdrawn from the dataset

### DIFF
--- a/lib/fpv/config.ts
+++ b/lib/fpv/config.ts
@@ -8,3 +8,6 @@ export const SCENE_BASE = `${CDN}/scenes`;
 export const THUMB_BASE = `${CDN}/thumbnails`;
 export const DATA_URL = `${CDN}/data/videos.json`;
 export const REDIRECTS_URL = `${CDN}/data/redirects.json`;
+// IDs withdrawn from the dataset with no successor. Superseded IDs live in
+// REDIRECTS_URL and 301 instead; these 410 so crawlers drop them.
+export const REMOVED_URL = `${CDN}/data/removed.json`;

--- a/lib/fpv/types.ts
+++ b/lib/fpv/types.ts
@@ -39,6 +39,17 @@ export type RedirectManifest = {
   redirects: DatasetRedirect[];
 };
 
+export type DatasetRemoval = {
+  id: string;
+  removed_at: string;
+  reason: string;
+};
+
+export type RemovedManifest = {
+  schema_version: 1;
+  removed: DatasetRemoval[];
+};
+
 // Segment marker colors — same legend as the annotator.
 export const SEGMENT_TYPES: Record<string, { label: string; color: string }> = {
   banner_start: { label: "Banner", color: "#4a9eff" },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { REMOVED_URL } from "@/lib/fpv/config";
+import type { RemovedManifest } from "@/lib/fpv/types";
+
+// Videos withdrawn from the dataset are gone for good — there is no successor to
+// redirect to (that is what data/redirects.json is for). Next has no way to set a
+// status code from a page, and notFound() would answer 404, which crawlers retry
+// for months. Middleware is the only layer that can answer 410 Gone, which tells
+// them to drop the URL. The dataset publishes independently of this site, so the
+// list is fetched rather than baked into the build.
+
+const TTL_MS = 5 * 60 * 1000;
+
+let cache: { at: number; ids: Set<string> } | null = null;
+
+async function removedIds(): Promise<Set<string>> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.ids;
+  try {
+    const res = await fetch(REMOVED_URL, { cache: "no-store" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const payload = (await res.json()) as RemovedManifest;
+    cache = { at: Date.now(), ids: new Set(payload.removed.map((r) => r.id)) };
+  } catch {
+    // Fail open — a manifest hiccup must not take down live pages. Stamp the
+    // cache either way so a persistent failure doesn't refetch on every request.
+    cache = { at: Date.now(), ids: cache?.ids ?? new Set() };
+  }
+  return cache.ids;
+}
+
+export async function middleware(request: NextRequest) {
+  // /fpv/{video,scene}/<slug>/ — and /<slug>/opengraph-image, which shares it.
+  const slug = request.nextUrl.pathname.split("/").filter(Boolean)[2];
+  if (!slug) return NextResponse.next();
+
+  const removed = await removedIds();
+  if (!removed.has(slug)) return NextResponse.next();
+
+  return new NextResponse("410 Gone — this entry was removed from the dataset.\n", {
+    status: 410,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=3600",
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/fpv/video/:path*", "/fpv/scene/:path*"],
+};


### PR DESCRIPTION
Eight `/fpv/` URLs are dead in production, found while checking the Vercel logs. Six are videos deliberately dropped in the dataset's "Remove excluded videos from catalog" pass, with no successor to redirect to — crawlers have been re-requesting them ever since, because a 404 invites retries for months and a 410 does not.

## Why middleware

`resolveLegacySlug` already handles the *superseded* case off `data/redirects.json`. The *withdrawn* case needs a 410, and a page cannot set a status code in Next — `notFound()` answers 404. Middleware is the only layer that can.

- The tombstone manifest is **fetched, not baked in**, because the dataset publishes on its own cadence (same reasoning as `redirects.json`).
- Cached in module scope for 5 minutes, so the per-request cost after the first is a `Set` lookup.
- **Fails open**: a fetch failure stamps the cache and serves normally, so an unreachable manifest degrades to today's 404 rather than taking down live pages.
- Matcher is scoped to `/fpv/video/:path*` and `/fpv/scene/:path*` only.

## Verified against a local fixture manifest

| case | result |
|---|---|
| tombstoned slug, `/fpv/video/` and `/fpv/scene/` | 410 |
| their `opengraph-image` routes | 410 |
| live video / scene / gallery pages | 200 |
| unknown slug, not tombstoned | 404 |
| existing barashit redirect | 308 |
| manifest unreachable → every live page | 200 |

`tsc --noEmit`, `next lint` and `next build` all pass; middleware registers at 34.4 kB.

## Note

The two duplicate slugs are handled as 301s in the dataset PR and need no change here — `resolveLegacySlug` picks them up from `redirects.json` automatically once published, with no site deploy.

Pairs with itamarwe/fpv-drone-strikes-lebanon-dataset#34, which publishes `data/removed.json`. Merge order does not matter: until that lands, this fails open and behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)