### PR TITLE
Drop the hardcoded barashit redirect; let the manifest be the source of truth

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -41,20 +41,16 @@ const nextConfig: NextConfig = {
   // Permanent (301/308) redirects from every legacy Jekyll URL to the new
   // clean URL, so existing links and search-engine results keep working.
   // The Portfolio page was merged into About, so /portfolio/ now redirects there.
+  //
+  // Renamed FPV slugs are deliberately absent: they are served by
+  // resolveLegacySlug from the dataset's own data/redirects.json, so a rename
+  // takes effect on the next publish without redeploying this site. Hardcoding
+  // them here too meant every rename needed a matching entry in two places, and
+  // a forgotten one is a dead URL.
   async redirects() {
     return [
       ...legacyRedirects,
       { source: "/portfolio", destination: "/about/", permanent: true },
-      {
-        source: "/fpv/video/2026-05-26_anti_drone_platform_barashit",
-        destination: "/fpv/video/2026-05-26_anti_drone_platform_biranit/",
-        permanent: true,
-      },
-      {
-        source: "/fpv/scene/2026-05-26_anti_drone_platform_barashit",
-        destination: "/fpv/scene/2026-05-26_anti_drone_platform_biranit/",
-        permanent: true,
-      },
     ];
   },
 };


### PR DESCRIPTION
The `barashit` → `biranit` rename was pinned in [next.config.ts](next.config.ts) as two static redirects, while `resolveLegacySlug` already serves the same rename from the dataset's `data/redirects.json`.

Two sources for one fact. Every future rename needed a matching entry in both places, and a forgotten one is a dead URL — the same class of bug that just left eight `/fpv/` URLs 404ing. It also defeats the manifest's design, which is that a rename takes effect on the next dataset publish **without redeploying this site**.

## Verification

The static redirect was intercepting these requests, so the manifest path had never actually run in production. Removed it first, then confirmed `resolveLegacySlug` takes over cleanly:

| URL | status | final |
|---|---|---|
| `/fpv/video/…barashit` | 308 → 200 | `/fpv/video/…biranit/` |
| `/fpv/video/…barashit/` | 308 → 200 | `/fpv/video/…biranit/` |
| `/fpv/scene/…barashit` | 308 → 200 | `/fpv/scene/…biranit/` |
| `/fpv/scene/…barashit/` | 308 → 200 | `/fpv/scene/…biranit/` |

Same status code and same destination as the static redirect gave. No regressions: legacy Jekyll URLs still 308 (`/drones/2024/12/07/how-does-a-drone-fly.html` → `/blog/how-does-a-drone-fly/`), `/portfolio` still lands on `/about/`, unknown FPV slugs still 404.

`tsc --noEmit`, `next lint` and `next build` all pass.

Independent of #104 — no overlapping files, either order merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)